### PR TITLE
Infrustructure fixes (bundler + travis)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ rvm:
 sudo: false
 before_install: gem install bundler -v 1.16.0
 cache: bundler
+bundler_args: --binstubs
 script:
   - bin/rubocop
   - bin/rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
 language: ruby
 rvm:
-- 2.3.5
-- 2.4.2
-- 2.2.7
-- ruby-head
-- jruby-head
+  - 2.3.5
+  - 2.4.2
+  - 2.2.7
+  - ruby-head
+  - jruby-head
 
 sudo: false
-before_install: gem install bundler -v 1.15.3
+before_install: gem install bundler -v 1.16.0
 cache: bundler
-script: bundle exec rspec
+script:
+  - bin/rubocop
+  - bin/rspec

--- a/bin/console
+++ b/bin/console
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-
 # frozen_string_literal: true
 
 require 'bundler/setup'

--- a/bin/rspec
+++ b/bin/rspec
@@ -1,0 +1,13 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+bundle_binstub = File.expand_path('../bundle', __FILE__)
+load(bundle_binstub) if File.file?(bundle_binstub)
+
+require 'pathname'
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', Pathname.new(__FILE__).realpath)
+
+require 'rubygems'
+require 'bundler/setup'
+
+load Gem.bin_path('rspec-core', 'rspec')

--- a/bin/rubocop
+++ b/bin/rubocop
@@ -1,0 +1,13 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+bundle_binstub = File.expand_path('../bundle', __FILE__)
+load(bundle_binstub) if File.file?(bundle_binstub)
+
+require 'pathname'
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', Pathname.new(__FILE__).realpath)
+
+require 'rubygems'
+require 'bundler/setup'
+
+load Gem.bin_path('rubocop', 'rubocop')

--- a/evil_events.gemspec
+++ b/evil_events.gemspec
@@ -38,8 +38,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov',      '0.14.1'
   spec.add_development_dependency 'simplecov-json', '0.2'
   spec.add_development_dependency 'rubocop',        '0.51.0'
-  spec.add_development_dependency 'bundler',        '1.15.4'
   spec.add_development_dependency 'rake',           '12.2.1'
   spec.add_development_dependency 'rspec',          '3.7.0'
   spec.add_development_dependency 'rubocop-rspec',  '1.19.0'
+
+  spec.add_development_dependency 'bundler'
 end


### PR DESCRIPTION
- Bundler: up to 1.16.0
- Travis: use `binstubs` script series instead of `bundle exec`