### PR TITLE
Access to the list of registered event classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,13 @@ All notable changes to this project will be documented in this file.
   - New utility for generating the custom coercive types: `EvilEvents::Shared::TypeConverter`
   - `AbstractEvent` supports new coercive types (metadata and payload are supported)
   - Configuration point for coercive types: `EvilEvents::Config.setup_types { |types| ... }`
-  - Configuration point for adapters: `EvilEvents::Config.setup_adapters { |adapters| ... }`
+- Configuration point for adapters: `EvilEvents::Config.setup_adapters { |adapters| ... }`
 - General class for internal errors: now all internal `*Error` classes inherits from `EvilEvents::Core::Error`
+- Access to the list of registered event classes via `EvilEvents::Application.registered_events`
 
 ### [Changed]
 - Renamed config opts aggregator: `EvilEvents::Config.config` => `EvilEvents::Config.options`
-- Move adapters config object to the appropriate place: `EvilEvents::Adapters` => `EvilEvents::Config::Adapters`
+- Moved adapters config object: `EvilEvents::Adapters` => `EvilEvents::Config::Adapters`
 
 ### [Fixed]
 - Fixed a bug when an event created by an exceptional block still remains in the internal event registry

--- a/lib/evil_events.rb
+++ b/lib/evil_events.rb
@@ -23,4 +23,5 @@ module EvilEvents
   require_relative 'evil_events/emitter'
   require_relative 'evil_events/subscriber_mixin'
   require_relative 'evil_events/dispatcher_mixin'
+  require_relative 'evil_events/application'
 end

--- a/lib/evil_events/application.rb
+++ b/lib/evil_events/application.rb
@@ -1,8 +1,13 @@
 # frozen_string_literal: true
 
 module EvilEvents
+  # @api public
+  # @since 0.2.0
   module Application
     class << self
+      # @see EvilEvents::Core::System
+      # @api public
+      # @since 0.2.0
       def registered_events
         EvilEvents::Core::Bootstrap[:event_system].registered_events
       end

--- a/lib/evil_events/application.rb
+++ b/lib/evil_events/application.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module EvilEvents
+  module Application
+    class << self
+      def registered_events
+        EvilEvents::Core::Bootstrap[:event_system].registered_events
+      end
+    end
+  end
+end

--- a/lib/evil_events/core/events/manager_registry.rb
+++ b/lib/evil_events/core/events/manager_registry.rb
@@ -106,6 +106,15 @@ module EvilEvents::Core::Events
       managers.key?(event_class)
     end
 
+    # @return [Hash]
+    #
+    # @since 0.2.0
+    def managed_events_map
+      managed_events.each_with_object({}) do |event, accumulator|
+        accumulator[event.type] = event
+      end
+    end
+
     private
 
     # @return [Array<EvilEvents::Core::Events::AbstractEvent>]

--- a/lib/evil_events/core/events/serializers.rb
+++ b/lib/evil_events/core/events/serializers.rb
@@ -4,6 +4,7 @@ module EvilEvents::Core::Events
   # @api private
   # @since 0.1.0
   class Serializers
+    # @since 0.1.0
     extend EvilEvents::Shared::DependencyContainer::Mixin
 
     # @since 0.1.0

--- a/lib/evil_events/core/system.rb
+++ b/lib/evil_events/core/system.rb
@@ -34,6 +34,7 @@ module EvilEvents::Core
                    :unregister_event_class,
                    :manager_of_event,
                    :manager_of_event_type,
+                   :registered_events,
                    :resolve_event_class,
                    :resolve_event_object,
                    :managed_event?

--- a/lib/evil_events/core/system/event_manager.rb
+++ b/lib/evil_events/core/system/event_manager.rb
@@ -96,6 +96,13 @@ class EvilEvents::Core::System
       manager_of_event_type(event_type).event_class
     end
 
+    # @return [Hash]
+    #
+    # @since 0.2.0
+    def registered_events
+      manager_registry.managed_events_map
+    end
+
     # @param event_class [EvilEvents::Core::Events::AbstractEvent]
     # @return [Boolean]
     #

--- a/lib/evil_events/core/system/mock.rb
+++ b/lib/evil_events/core/system/mock.rb
@@ -94,5 +94,9 @@ class EvilEvents::Core::System
     # @see EvilEvents::Core::System
     # @since 0.2.0
     def resolve_type(type, **options); end
+
+    # @see EvilEvents::Core::System
+    # @since 0.2.0
+    def registered_events; end
   end
 end

--- a/spec/integration/event_creation_spec.rb
+++ b/spec/integration/event_creation_spec.rb
@@ -175,6 +175,24 @@ describe 'Event Creation', :stub_event_system do
         EvilEvents::Core::Events::ManagerRegistry::AlreadyManagedEventClassError
       )
     end
+
+    specify 'list of created event classes' do
+      class DeployFinished < EvilEvents::Event['deploy_finished']
+      end
+
+      class PullRequestCreated < EvilEvents::Event['pull_request_created']
+      end
+
+      withdraw_processed = EvilEvents::Event.define('withdraw_processed')
+      deposit_rejected   = EvilEvents::Event.define('deposit_rejected')
+
+      expect(EvilEvents::Application.registered_events).to match(
+        'deploy_finished'      => DeployFinished,
+        'pull_request_created' => PullRequestCreated,
+        'withdraw_processed'   => withdraw_processed,
+        'deposit_rejected'     => deposit_rejected
+      )
+    end
   end
 
   describe 'object creation' do

--- a/spec/support/shared_examples/event_extensions/emittable_interface.rb
+++ b/spec/support/shared_examples/event_extensions/emittable_interface.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 shared_examples 'emittable interface' do
-  describe 'event invokation behaviour', :mock_event_system do
+  describe 'event invocation behaviour', :mock_event_system do
     describe '#emit!' do
       it 'delegates event handling process to the event system' do
         expect(EvilEvents::Core::Bootstrap[:event_system]).to(

--- a/spec/support/shared_examples/event_extensions/payloadable_interface.rb
+++ b/spec/support/shared_examples/event_extensions/payloadable_interface.rb
@@ -16,7 +16,7 @@ shared_examples 'payloadable interface' do
       let(:event_class) { Class.new(payloadable_abstraction) }
 
       describe '#attribute' do
-        it 'defines the payload attribute with a custom type', :stub_event_system do
+        it 'defines payload attribute with a custom type', :stub_event_system do
           # register two coercible types
           EvilEvents::Core::Bootstrap[:event_system].tap do |system|
             system.register_converter(:string,  ->(value) { value.to_s })

--- a/spec/units/evil_events/application_spec.rb
+++ b/spec/units/evil_events/application_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+describe EvilEvents::Application, :stub_event_system do
+  describe '.registered_events' do
+    it 'returns a list of the all created event classes in { type => class } form' do
+      expect(described_class.registered_events).to eq({})
+
+      event_type  = gen_str
+      event_class = EvilEvents::Event.define(event_type)
+
+      expect(described_class.registered_events).to match(
+        event_type => event_class
+      )
+
+      match_lost_alias = gen_str
+      match_lost_event = Class.new(EvilEvents::Event[match_lost_alias])
+
+      expect(described_class.registered_events).to match(
+        match_lost_alias => match_lost_event,
+        event_type       => event_class
+      )
+    end
+  end
+
+  it 'exceptional event initialization code doesnt affect event class list' do
+    EvilEvents::Event.define(gen_str) { raise } rescue nil
+
+    expect(described_class.registered_events).to eq({})
+
+    event_class = EvilEvents::Event.define(gen_str)
+    EvilEvents::Event.define(gen_str) { raise } rescue nil
+
+    expect(described_class.registered_events).to match(
+      event_class.type => event_class
+    )
+
+    another_event_class = EvilEvents::Event.define(gen_str)
+    EvilEvents::Event.define(gen_str) { raise } rescue nil
+
+    expect(described_class.registered_events).to match(
+      event_class.type => event_class,
+      another_event_class.type => another_event_class
+    )
+  end
+end

--- a/spec/units/evil_events/core/events/event_extensions/metadata_extendable_spec.rb
+++ b/spec/units/evil_events/core/events/event_extensions/metadata_extendable_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe EvilEvents::Core::Events::EventExtensions::MetadataExtendable do
+describe EvilEvents::Core::Events::EventExtensions::MetadataExtendable, :stub_event_system do
   it_behaves_like 'metadata extendable interface' do
     let(:metadata_extendable_abstraction) do
       build_event_class_signature do |klass|

--- a/spec/units/evil_events/core/events/event_extensions/payloadable_spec.rb
+++ b/spec/units/evil_events/core/events/event_extensions/payloadable_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe EvilEvents::Core::Events::EventExtensions::Payloadable do
+describe EvilEvents::Core::Events::EventExtensions::Payloadable, :stub_event_system do
   it_behaves_like 'payloadable interface' do
     let(:payloadable_abstraction) do
       build_event_class_signature do |klass|

--- a/spec/units/evil_events/core/events/manager_registry_spec.rb
+++ b/spec/units/evil_events/core/events/manager_registry_spec.rb
@@ -157,6 +157,31 @@ describe EvilEvents::Core::Events::ManagerRegistry do
     end
 
     describe 'common interface' do
+      describe '#managed_events_map' do
+        it 'retruns an event class list in event_class.type => event_class hash form' do
+          expect(registry.managed_events_map).to eq({}) # empty in start
+
+          registry.register(first_manager)
+          expect(registry.managed_events_map).to match(
+            first_event_class.type => first_event_class
+          )
+
+          registry.register(second_manager)
+          expect(registry.managed_events_map).to match(
+            first_event_class.type  => first_event_class,
+            second_event_class.type => second_event_class
+          )
+
+          registry.unregister(first_manager)
+          expect(registry.managed_events_map).to match(
+            second_event_class.type => second_event_class
+          )
+
+          registry.unregister(second_manager)
+          expect(registry.managed_events_map).to eq({})
+        end
+      end
+
       describe '#managed_event?' do
         it 'required event class is managed => true, otherwise => false' do
           expect(registry.managed_event?(first_event_class)).to  eq(false)

--- a/spec/units/evil_events/core/system/event_manager_spec.rb
+++ b/spec/units/evil_events/core/system/event_manager_spec.rb
@@ -82,6 +82,35 @@ describe EvilEvents::Core::System::EventManager, :stub_event_system do
       end
     end
 
+    describe '#registered_events' do
+      it 'returns a list of created event classes in event_class#type_alias => event_class form' do
+        expect(event_manager.registered_events).to eq({})
+
+        event_manager.register_event_class(event_class)
+
+        expect(event_manager.registered_events).to match(
+          event_class.type => event_class
+        )
+
+        event_manager.register_event_class(another_event_class)
+
+        expect(event_manager.registered_events).to match(
+          event_class.type => event_class,
+          another_event_class.type => another_event_class
+        )
+
+        event_manager.unregister_event_class(event_class)
+
+        expect(event_manager.registered_events).to match(
+          another_event_class.type => another_event_class
+        )
+
+        event_manager.unregister_event_class(another_event_class)
+
+        expect(event_manager.registered_events).to eq({})
+      end
+    end
+
     describe '#resolve_event_object' do
       context 'when required event class is registered' do
         let(:event_class) do

--- a/spec/units/evil_events/emitter_spec.rb
+++ b/spec/units/evil_events/emitter_spec.rb
@@ -5,7 +5,7 @@ describe EvilEvents::Emitter, :stub_event_system do
 
   describe '.emit' do
     it 'receives event attributes and delegates event handling process to the event system' do
-      event_type       = 'suite_event'
+      event_type = 'suite_event'
       event_attributes = { a: 10, b: 20, c: 30 }
 
       expect(event_system).to(


### PR DESCRIPTION
Closes #6

Final implementation:

```ruby
# event classes 
DeployFinished = Class.new(EvilEvents::Event['deploy_finished'])
PullRequestCreated = Class.new(EvilEvents::Event['pull_request_created']) 
EvilEvents::Event.define('withdraw_processed')
EvilEvents::Event.define('deposit_rejected')

# getting an event class list
EvilEvents::Application.registered_events

# result
{
  "deploy_finished"      => DeployFinished,
  "pull_request_created" => PullRequestCreated,
  "withdraw_processed"   => #<Class:0x00007f9fbe8a52e0>,
  "deposit_rejected"     => #<Class:0x00007f9fbe8a42f0>
}
```