### PR TITLE
Improvement: subscribe to event list

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,2 +1,0 @@
-ruby:
-  config_file: .rubocop.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,6 +44,9 @@ Style/EmptyCaseCondition:
 Style/FrozenStringLiteralComment:
   Enabled: true
 
+Style/InverseMethods:
+  Enabled: false
+
 Style/ParallelAssignment:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -53,6 +53,9 @@ Style/ParallelAssignment:
 Style/CommentedKeyword:
   Enabled: false
 
+Lint/AmbiguousRegexpLiteral:
+  Enabled: false
+
 Naming/FileName:
   Enabled: false
 
@@ -79,7 +82,7 @@ RSpec/HookArgument:
   Enabled: false
 
 RSpec/NestedGroups:
-  Max: 5
+  Max: 6
 
 RSpec/MessageSpies:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ All notable changes to this project will be documented in this file.
   -  metadata attributes schema
   -  payload attributes schema
   -  string type alias
+- Event subscriptions via event type alias pattern (Regexp) and conditional proc (Proc)
+- The ability to subscribe to a list of events (via list of event type attributes)
 
 ### [Changed]
 - Renamed config opts aggregator: `EvilEvents::Config.config` => `EvilEvents::Config.options`

--- a/lib/evil_events/core/error.rb
+++ b/lib/evil_events/core/error.rb
@@ -4,4 +4,5 @@ module EvilEvents::Core
   # @api private
   # @since 0.2.0
   Error = Class.new(StandardError)
+  ArgumentError = Class.new(ArgumentError)
 end

--- a/lib/evil_events/core/events/manager_registry.rb
+++ b/lib/evil_events/core/events/manager_registry.rb
@@ -45,8 +45,23 @@ module EvilEvents::Core::Events
     #
     # @since 0.1.0
     def manager_of_event_type(event_type)
-      event_class = managed_events.find { |managed_event| managed_event.type == event_type }
+      event_class = managed_events.find do |managed_event|
+        managed_event.type == event_type
+      end
+
       manager_of_event(event_class)
+    end
+
+    # @param event_pattern [Regexp]
+    # @return [Array<EvilEvents::Core::Events::Manager>]
+    #
+    # @since 0.2.0
+    def managers_of_event_pattern(event_pattern)
+      event_classes = managed_events.select do |managed_event|
+        managed_event.type.match(event_pattern)
+      end
+
+      event_classes.map { |event_class| manager_of_event(event_class) }
     end
 
     # @param manager [EvilEvents::Core::Events::Manager]

--- a/lib/evil_events/core/events/manager_registry.rb
+++ b/lib/evil_events/core/events/manager_registry.rb
@@ -64,6 +64,18 @@ module EvilEvents::Core::Events
       event_classes.map { |event_class| manager_of_event(event_class) }
     end
 
+    # @param event_condition [Proc]
+    # @return [Array<EvilEvents::Core::Event::Manager>]
+    #
+    # @since 0.2.0
+    def managers_of_event_condition(event_condition)
+      event_classes = managed_events.select do |managed_event|
+        !!event_condition.call(managed_event.type)
+      end
+
+      event_classes.map { |event_class| manager_of_event(event_class) }
+    end
+
     # @param manager [EvilEvents::Core::Events::Manager]
     # @raise [IncorrectManagerObjectError]
     # @raise [AlreadyManagedEventClassError]

--- a/lib/evil_events/core/events/subscriber/mixin.rb
+++ b/lib/evil_events/core/events/subscriber/mixin.rb
@@ -4,21 +4,25 @@ class EvilEvents::Core::Events::Subscriber
   # @api public
   # @since 0.1.0
   Mixin = EvilEvents::Shared::ClonableModuleBuilder.build do
-    # @param event_type [String, Class{EvilEvents::Core::Events::AbstractEvent}]
+    # @param event_type [Array<String, Class{EvilEvents::Core::Events::AbstractEvent}, Regexp>]
     # @param delegator [String, Symbol, NilClass]
-    # @raise [IncompatibleEventAttrTypeError]
+    # @raise [ArgumentError]
     #
-    # @since 0.1.0
-    def subscribe_to(event_type, delegator: nil)
-      case event_type
-      when Class
-        EvilEvents::Core::Bootstrap[:event_system].observe(event_type, self, delegator)
-      when String
-        EvilEvents::Core::Bootstrap[:event_system].raw_observe(event_type, self, delegator)
-      when Regexp
-        EvilEvents::Core::Bootstrap[:event_system].observe_list(event_type, self, delegator)
-      else
-        raise ArgumentError
+    # @since 0.2.0
+    def subscribe_to(*event_types, delegator: nil)
+      raise ArgumentError unless event_types.all? do |event_type|
+        event_type.is_a?(Class) || event_type.is_a?(String) || event_type.is_a?(Regexp)
+      end
+
+      event_types.each do |event_type|
+        case event_type
+        when Class
+          EvilEvents::Core::Bootstrap[:event_system].observe(event_type, self, delegator)
+        when String
+          EvilEvents::Core::Bootstrap[:event_system].raw_observe(event_type, self, delegator)
+        when Regexp
+          EvilEvents::Core::Bootstrap[:event_system].observe_list(event_type, self, delegator)
+        end
       end
     end
   end

--- a/lib/evil_events/core/events/subscriber/mixin.rb
+++ b/lib/evil_events/core/events/subscriber/mixin.rb
@@ -6,11 +6,11 @@ class EvilEvents::Core::Events::Subscriber
   Mixin = EvilEvents::Shared::ClonableModuleBuilder.build do
     # @param event_type [Array<String, Class{EvilEvents::Core::Events::AbstractEvent}, Regexp>]
     # @param delegator [String, Symbol, NilClass]
-    # @raise [ArgumentError]
+    # @raise [EvilEvents::Core::ArgumentError]
     #
     # @since 0.2.0
     def subscribe_to(*event_types, delegator: nil)
-      raise ArgumentError unless event_types.all? do |event_type|
+      raise EvilEvents::Core::ArgumentError unless event_types.all? do |event_type|
         event_type.is_a?(Class) ||
         event_type.is_a?(String) ||
         event_type.is_a?(Regexp) ||

--- a/lib/evil_events/core/events/subscriber/mixin.rb
+++ b/lib/evil_events/core/events/subscriber/mixin.rb
@@ -15,6 +15,8 @@ class EvilEvents::Core::Events::Subscriber
         EvilEvents::Core::Bootstrap[:event_system].observe(event_type, self, delegator)
       when String
         EvilEvents::Core::Bootstrap[:event_system].raw_observe(event_type, self, delegator)
+      when Regexp
+        EvilEvents::Core::Bootstrap[:event_system].observe_list(event_type, self, delegator)
       else
         raise ArgumentError
       end

--- a/lib/evil_events/core/events/subscriber/mixin.rb
+++ b/lib/evil_events/core/events/subscriber/mixin.rb
@@ -11,17 +11,20 @@ class EvilEvents::Core::Events::Subscriber
     # @since 0.2.0
     def subscribe_to(*event_types, delegator: nil)
       raise ArgumentError unless event_types.all? do |event_type|
-        event_type.is_a?(Class) || event_type.is_a?(String) || event_type.is_a?(Regexp)
+        event_type.is_a?(Class) ||
+        event_type.is_a?(String) ||
+        event_type.is_a?(Regexp) ||
+        event_type.is_a?(Proc)
       end
+
+      event_system = EvilEvents::Core::Bootstrap[:event_system]
 
       event_types.each do |event_type|
         case event_type
-        when Class
-          EvilEvents::Core::Bootstrap[:event_system].observe(event_type, self, delegator)
-        when String
-          EvilEvents::Core::Bootstrap[:event_system].raw_observe(event_type, self, delegator)
-        when Regexp
-          EvilEvents::Core::Bootstrap[:event_system].observe_list(event_type, self, delegator)
+        when Class  then event_system.observe(event_type, self, delegator)
+        when String then event_system.raw_observe(event_type, self, delegator)
+        when Regexp then event_system.observe_list(event_type, self, delegator)
+        when Proc   then event_system.conditional_observe(event_type, self, delegator)
         end
       end
     end

--- a/lib/evil_events/core/system.rb
+++ b/lib/evil_events/core/system.rb
@@ -29,6 +29,7 @@ module EvilEvents::Core
     def_delegators :event_manager,
                    :observe,
                    :raw_observe,
+                   :observe_list,
                    :observers,
                    :register_event_class,
                    :unregister_event_class,

--- a/lib/evil_events/core/system.rb
+++ b/lib/evil_events/core/system.rb
@@ -30,6 +30,7 @@ module EvilEvents::Core
                    :observe,
                    :raw_observe,
                    :observe_list,
+                   :conditional_observe,
                    :observers,
                    :register_event_class,
                    :unregister_event_class,

--- a/lib/evil_events/core/system/event_manager.rb
+++ b/lib/evil_events/core/system/event_manager.rb
@@ -46,6 +46,17 @@ class EvilEvents::Core::System
                       .each { |manager| manager.observe(raw_subscriber, delegator) }
     end
 
+    # @param event_condition [Proc]
+    # @param raw_subscriber [Mixed]
+    # @param delegator [String, Symbol, NilClass]
+    # @return void
+    #
+    # @since 0.2.0
+    def conditional_observe(event_condition, raw_subscriber, delegator)
+      manager_registry.managers_of_event_condition(event_condition)
+                      .each { |manager| manager.observe(raw_subscriber, delegator) }
+    end
+
     # @param event_class [Class{EvilEvents::Core::Events::AbstractEvent}]
     # @return [Array<EvilEvents::Core::Events::Subscriber>]
     #

--- a/lib/evil_events/core/system/event_manager.rb
+++ b/lib/evil_events/core/system/event_manager.rb
@@ -14,7 +14,7 @@ class EvilEvents::Core::System
     end
 
     # @param event_class [Class{Evilevents::Core::Events::AbstractEvent}]
-    # @param raw_subscriber [Object]
+    # @param raw_subscriber [Mixed]
     # @param delegator [String, Symbol, NilClass]
     # @return void
     #
@@ -25,7 +25,7 @@ class EvilEvents::Core::System
     end
 
     # @param event_type [String, Symbol]
-    # @param raw_subscriber [Object]
+    # @param raw_subscriber [Mixed]
     # @param delegator [String, Symbol, NilClass]
     # @return void
     #
@@ -33,6 +33,17 @@ class EvilEvents::Core::System
     def raw_observe(event_type, raw_subscriber, delegator)
       manager_registry.manager_of_event_type(event_type)
                       .observe(raw_subscriber, delegator)
+    end
+
+    # @param event_pattern [Regexp]
+    # @param raw_subscriber [Mixed]
+    # @param delegator [String, Symbol, NilClass]
+    # @return void
+    #
+    # @since 0.2.0
+    def observe_list(event_pattern, raw_subscriber, delegator)
+      manager_registry.managers_of_event_pattern(event_pattern)
+                      .each { |manager| manager.observe(raw_subscriber, delegator) }
     end
 
     # @param event_class [Class{EvilEvents::Core::Events::AbstractEvent}]

--- a/lib/evil_events/core/system/mock.rb
+++ b/lib/evil_events/core/system/mock.rb
@@ -28,6 +28,10 @@ class EvilEvents::Core::System
     def observe_list(event_pattern, raw_subscriber, delegator); end
 
     # @see EvilEvents::Core::System
+    # @since 0.2.0
+    def conditional_observe(event_condition, raw_subscriber, delegator); end
+
+    # @see EvilEvents::Core::System
     # @since 0.1.0
     def observers(event_class); end
 

--- a/lib/evil_events/core/system/mock.rb
+++ b/lib/evil_events/core/system/mock.rb
@@ -24,6 +24,10 @@ class EvilEvents::Core::System
     def raw_observe(event_type, raw_subscriber, delegator); end
 
     # @see EvilEvents::Core::System
+    # @since 0.2.0
+    def observe_list(event_pattern, raw_subscriber, delegator); end
+
+    # @see EvilEvents::Core::System
     # @since 0.1.0
     def observers(event_class); end
 

--- a/spec/integration/event_broadcasting_spec.rb
+++ b/spec/integration/event_broadcasting_spec.rb
@@ -44,7 +44,7 @@ describe 'Event Broadcasting', :stub_event_system do
         @event_counter = Concurrent::Atom.new(0)
       end
 
-      def increase!(event)
+      def increase!(_event)
         event_counter.swap { |count| count + 1 }
       end
 

--- a/spec/integration/event_broadcasting_spec.rb
+++ b/spec/integration/event_broadcasting_spec.rb
@@ -14,10 +14,6 @@ describe 'Event Broadcasting', :stub_event_system do
         @event_store = []
       end
 
-      def clear!
-        event_store.clear
-      end
-
       def store(event)
         event_store << event
       end
@@ -34,19 +30,38 @@ describe 'Event Broadcasting', :stub_event_system do
         @events = []
       end
 
-      def clear!
-        events.clear
-      end
-
       def push(event)
         events << event
       end
     end.new
   end
 
+  let(:event_counter) do
+    Class.new do
+      include EvilEvents::SubscriberMixin
+
+      def initialize
+        @event_counter = Concurrent::Atom.new(0)
+      end
+
+      def increase!(event)
+        event_counter.swap { |count| count + 1 }
+      end
+
+      def count
+        event_counter.value
+      end
+
+      private
+
+      attr_reader :event_counter
+    end.new
+  end
+
   before do
     stub_const('::ElasticSearchStub', elastic_search)
     stub_const('::EventStoreStub', event_store)
+    stub_const('::EventCounter', event_counter)
 
     EvilEvents::Config.configure do |config|
       config.logger = silent_logger
@@ -78,12 +93,14 @@ describe 'Event Broadcasting', :stub_event_system do
     end
 
     # subscribe to events
-    ElasticSearchStub.subscribe_to 'overwatch_released', delegator: :store # via identificator
-    ElasticSearchStub.subscribe_to MatchLost, delegator: :store # via class
+    ElasticSearchStub.subscribe_to 'overwatch_released', MatchLost, delegator: :store
+    EventStoreStub.subscribe_to    'match_lost', OverwatchReleased, delegator: :push
 
-    # subscribe to events
-    EventStoreStub.subscribe_to OverwatchReleased, delegator: :push # via class
-    EventStoreStub.subscribe_to 'match_lost', delegator: :push # via identificator
+    EventCounter.subscribe_to(
+      ->(event_type) { event_type == 'match_lost' },
+      /.*?overwatch.*?/i,
+      delegator: :increase!
+    )
 
     # check the first approach: event objects
     # create event objects
@@ -103,6 +120,7 @@ describe 'Event Broadcasting', :stub_event_system do
     # check state of subscribers
     expect(ElasticSearchStub.event_store).to contain_exactly(match_event, overwatch_event)
     expect(EventStoreStub.events).to contain_exactly(match_event, overwatch_event)
+    expect(EventCounter.count).to eq(2)
 
     # check log output of the first event data
     expect(silent_output.string).to include(
@@ -153,6 +171,9 @@ describe 'Event Broadcasting', :stub_event_system do
     # BROADCASTING: attributes aproach
     EvilEvents::Emitter.emit('match_lost', **match_lost_attrs)
     EvilEvents::Emitter.emit('overwatch_released', **overwatch_released_attrs)
+
+    # check state of subscriber
+    expect(EventCounter.count).to eq(4)
 
     # check state of subscriber
     # check consistency
@@ -209,7 +230,7 @@ describe 'Event Broadcasting', :stub_event_system do
     )
 
     # check log output for the notifier activity
-    [ElasticSearchStub, EventStoreStub].each do |subscriber|
+    [ElasticSearchStub, EventStoreStub, EventCounter].each do |subscriber|
       expect(silent_output.string).to match(
         Regexp.union(
           /\[EvilEvents:EventProcessed\(match_lost\)\s/,

--- a/spec/support/shared_examples/event_subscriber_component.rb
+++ b/spec/support/shared_examples/event_subscriber_component.rb
@@ -104,50 +104,50 @@ shared_context 'event subscriber component' do
         expect(another_event_class.observers).to be_empty
 
         # true for all even types
-        subscribeable.subscribe_to (-> (event_type) { event_type.match(/.+/) }), delegator: :boot
+        subscribeable.subscribe_to ->(event_type) { event_type.match(/.+/) }, delegator: :boot
 
         expect(event_class.observers).to contain_exactly(
-          have_attributes(source_object: subscribeable,delegator: :boot)
+          have_attributes(source_object: subscribeable, delegator: :boot)
         )
 
         expect(another_event_class.observers).to contain_exactly(
-          have_attributes(source_object: subscribeable,delegator: :boot)
+          have_attributes(source_object: subscribeable, delegator: :boot)
         )
 
         # false for all event types
-        subscribeable.subscribe_to (-> (event_type) { false })
+        subscribeable.subscribe_to ->(_event_type) { false }
 
         expect(event_class.observers).to contain_exactly(
-          have_attributes(source_object: subscribeable,delegator: :boot)
+          have_attributes(source_object: subscribeable, delegator: :boot)
         )
 
         expect(another_event_class.observers).to contain_exactly(
-          have_attributes(source_object: subscribeable,delegator: :boot)
+          have_attributes(source_object: subscribeable, delegator: :boot)
         )
 
         # true for test_event only
-        subscribeable.subscribe_to (-> (event_type) { event_type == 'test_event' })
+        subscribeable.subscribe_to ->(event_type) { event_type == 'test_event' }
 
         expect(event_class.observers).to contain_exactly(
-          have_attributes(source_object: subscribeable,delegator: :boot),
-          have_attributes(source_object: subscribeable,delegator: :call)
+          have_attributes(source_object: subscribeable, delegator: :boot),
+          have_attributes(source_object: subscribeable, delegator: :call)
         )
 
         expect(another_event_class.observers).to contain_exactly(
-          have_attributes(source_object: subscribeable,delegator: :boot)
+          have_attributes(source_object: subscribeable, delegator: :boot)
         )
 
         # true for another_test_event only
-        subscribeable.subscribe_to (-> (event_type) { event_type == 'another_test_event' })
+        subscribeable.subscribe_to ->(event_type) { event_type == 'another_test_event' }
 
         expect(event_class.observers).to contain_exactly(
-          have_attributes(source_object: subscribeable,delegator: :boot),
-          have_attributes(source_object: subscribeable,delegator: :call)
+          have_attributes(source_object: subscribeable, delegator: :boot),
+          have_attributes(source_object: subscribeable, delegator: :call)
         )
 
         expect(another_event_class.observers).to contain_exactly(
-          have_attributes(source_object: subscribeable,delegator: :boot),
-          have_attributes(source_object: subscribeable,delegator: :call)
+          have_attributes(source_object: subscribeable, delegator: :boot),
+          have_attributes(source_object: subscribeable, delegator: :call)
         )
       end
 

--- a/spec/support/shared_examples/event_subscriber_component.rb
+++ b/spec/support/shared_examples/event_subscriber_component.rb
@@ -3,46 +3,166 @@
 shared_context 'event subscriber component' do
   describe 'subscriber component behavior' do
     let!(:event_class) { build_event_class('test_event') }
+    let!(:another_event_class) { build_event_class('another_test_event') }
 
     describe '#subscribe_to' do
-      it 'can subscribe an object to an event by an event class (by Class object)' do
+      it 'can subscribe an object to an event by event class (by Class object)' do
+        # subscribe to Event class
+        subscribeable.subscribe_to event_class, delegator: :test_call
+
+        expect(event_class.observers).to contain_exactly(
+          have_attributes(source_object: subscribeable, delegator: :test_call)
+        )
+        expect(another_event_class.observers).to be_empty
+
+        # subscribe to Event class
+        subscribeable.subscribe_to another_event_class, delegator: :uber_call
+
+        expect(event_class.observers).to contain_exactly(
+          have_attributes(source_object: subscribeable, delegator: :test_call)
+        )
+        expect(another_event_class.observers).to contain_exactly(
+          have_attributes(source_object: subscribeable, delegator: :uber_call)
+        )
+
+        # subscribe to non-event class
         expect do
-          subscribeable.subscribe_to event_class, delegator: :test_call
-        end.to change { event_class.observers.size }.from(0).to(1)
-
-        # fetch subcriber abstraction
-        wrapped_subscriber = event_class.observers.first
-        # get source subscriber object
-        source_subscriber  = wrapped_subscriber.source_object
-
-        expect(source_subscriber).to eq(subscribeable)
-        expect(wrapped_subscriber.delegator).to eq(:test_call)
+          subscribeable.subscribe_to gen_class, delegator: :uber_call
+        end.to raise_error(EvilEvents::Core::Events::ManagerRegistry::NonManagedEventClassError)
       end
 
-      it 'can subscribe an object to an event by an event type field (by String object)' do
+      it 'can subscribe an object to an event by event type field (by String object)' do
+        # subscribe to existing event
+        subscribeable.subscribe_to event_class.type, delegator: :invoke
+
+        expect(event_class.observers).to contain_exactly(
+          have_attributes(source_object: subscribeable, delegator: :invoke)
+        )
+        expect(another_event_class.observers).to be_empty
+
+        # subscribe to existing event
+        subscribeable.subscribe_to another_event_class.type, delegator: :invoke
+
+        expect(another_event_class.observers).to contain_exactly(
+          have_attributes(source_object: subscribeable, delegator: :invoke)
+        )
+        expect(event_class.observers).to contain_exactly(
+          have_attributes(source_object: subscribeable, delegator: :invoke)
+        )
+
+        # subscribe to unexistent event
         expect do
-          subscribeable.subscribe_to event_class.type, delegator: :invoke
-        end.to change { event_class.observers.size }.from(0).to(1)
-
-        # fetch subcriber abstraction
-        wrapped_subscriber = event_class.observers.first
-        # get source subscriber object
-        source_subscriber  = wrapped_subscriber.source_object
-
-        expect(source_subscriber).to eq(subscribeable)
-        expect(wrapped_subscriber.delegator).to eq(:invoke)
+          subscribeable.subscribe_to gen_str, delegator: gen_symb
+        end.to raise_error(EvilEvents::Core::Events::ManagerRegistry::NonManagedEventClassError)
       end
 
-      it 'can subscribe with globally preconfigured default delegator' do
+      it 'can subscribe to the list of events by event type alias pattern (by Regexp object)' do
+        # subscribe to test_event
+        subscribeable.subscribe_to /\Atest_[a-z]+\z/i, delegator: :process
+
+        expect(event_class.observers).to contain_exactly(
+          have_attributes(source_object: subscribeable, delegator: :process)
+        )
+        expect(another_event_class.observers).to be_empty
+
+        subscribeable.subscribe_to /\Aanother_.+\z/i, delegator: :invoke
+
+        expect(event_class.observers).to contain_exactly(
+          have_attributes(source_object: subscribeable, delegator: :process)
+        )
+        expect(another_event_class.observers).to contain_exactly(
+          have_attributes(source_object: subscribeable, delegator: :invoke)
+        )
+
+        # subscribe to all
+        subscribeable.subscribe_to /.+/, delegator: :call
+
+        expect(event_class.observers).to contain_exactly(
+          have_attributes(source_object: subscribeable, delegator: :process),
+          have_attributes(source_object: subscribeable, delegator: :call)
+        )
+        expect(another_event_class.observers).to contain_exactly(
+          have_attributes(source_object: subscribeable, delegator: :invoke),
+          have_attributes(source_object: subscribeable, delegator: :call)
+        )
+
+        # subscribe to nothing
+        subscribeable.subscribe_to /#{gen_str}/, delegator: gen_symb
+
+        expect(event_class.observers).to contain_exactly(
+          have_attributes(source_object: subscribeable, delegator: :process),
+          have_attributes(source_object: subscribeable, delegator: :call)
+        )
+        expect(another_event_class.observers).to contain_exactly(
+          have_attributes(source_object: subscribeable, delegator: :invoke),
+          have_attributes(source_object: subscribeable, delegator: :call)
+        )
+      end
+
+      it 'can subscribe to the list of events by conditional proc (by Proc object)' do
+        expect(event_class.observers).to be_empty
+        expect(another_event_class.observers).to be_empty
+
+        # true for all even types
+        subscribeable.subscribe_to (-> (event_type) { event_type.match(/.+/) }), delegator: :boot
+
+        expect(event_class.observers).to contain_exactly(
+          have_attributes(source_object: subscribeable,delegator: :boot)
+        )
+
+        expect(another_event_class.observers).to contain_exactly(
+          have_attributes(source_object: subscribeable,delegator: :boot)
+        )
+
+        # false for all event types
+        subscribeable.subscribe_to (-> (event_type) { false })
+
+        expect(event_class.observers).to contain_exactly(
+          have_attributes(source_object: subscribeable,delegator: :boot)
+        )
+
+        expect(another_event_class.observers).to contain_exactly(
+          have_attributes(source_object: subscribeable,delegator: :boot)
+        )
+
+        # true for test_event only
+        subscribeable.subscribe_to (-> (event_type) { event_type == 'test_event' })
+
+        expect(event_class.observers).to contain_exactly(
+          have_attributes(source_object: subscribeable,delegator: :boot),
+          have_attributes(source_object: subscribeable,delegator: :call)
+        )
+
+        expect(another_event_class.observers).to contain_exactly(
+          have_attributes(source_object: subscribeable,delegator: :boot)
+        )
+
+        # true for another_test_event only
+        subscribeable.subscribe_to (-> (event_type) { event_type == 'another_test_event' })
+
+        expect(event_class.observers).to contain_exactly(
+          have_attributes(source_object: subscribeable,delegator: :boot),
+          have_attributes(source_object: subscribeable,delegator: :call)
+        )
+
+        expect(another_event_class.observers).to contain_exactly(
+          have_attributes(source_object: subscribeable,delegator: :boot),
+          have_attributes(source_object: subscribeable,delegator: :call)
+        )
+      end
+
+      it 'delegator: can subscribe with globally preconfigured default delegator' do
+        global_delegator = gen_symb(only_letters: true)
+
         EvilEvents::Core::Bootstrap[:config].configure do |config|
-          config.subscriber.default_delegator = :subscribeable_test_call
+          config.subscriber.default_delegator = global_delegator
         end
 
         expect do
           subscribeable.subscribe_to event_class
         end.to change { event_class.observers.size }.from(0).to(1)
 
-        expect(event_class.observers.last.delegator).to eq(:subscribeable_test_call)
+        expect(event_class.observers.last.delegator).to eq(global_delegator)
       end
 
       it 'raises ArgumentError for non-string/non-class event type argument' do

--- a/spec/support/shared_examples/event_subscriber_component.rb
+++ b/spec/support/shared_examples/event_subscriber_component.rb
@@ -166,7 +166,10 @@ shared_context 'event subscriber component' do
       end
 
       it 'raises ArgumentError for non-string/non-class event type argument' do
-        expect { subscribeable.subscribe_to event_class.new }.to raise_error(ArgumentError)
+        expect do
+          subscribeable.subscribe_to event_class.new
+        end.to raise_error(EvilEvents::Core::ArgumentError)
+
         expect(event_class.observers).to be_empty
       end
 

--- a/spec/support/spec_support/fake_data_generator.rb
+++ b/spec/support/spec_support/fake_data_generator.rb
@@ -8,7 +8,6 @@ module SpecSupport::FakeDataGenerator
   FLOAT_RANGE     = (0.0..100.0)
   STR_LENGTH      = 10
   STR_LETTERS     = (('a'..'z').to_a | ('A'..'Z').to_a).freeze
-  CLASS_LIST      = [Object, Class, BasicObject].freeze
 
   FACTORY_METHODS = %i[
     gen_int
@@ -91,7 +90,7 @@ module SpecSupport::FakeDataGenerator
   end
 
   def gen_class
-    CLASS_LIST.sample
+    Class.new
   end
 
   def gen_proc

--- a/spec/units/evil_events/core/events/manager_registry_spec.rb
+++ b/spec/units/evil_events/core/events/manager_registry_spec.rb
@@ -256,20 +256,20 @@ describe EvilEvents::Core::Events::ManagerRegistry do
 
           describe '#managers_of_event_condition' do
             it 'returns a list of managers which aliases has passed required condition (proc)' do
-              condition = -> (event_type) { event_type.match(/\A[a-z]+_[a-z]+\z/i) }
+              condition = ->(event_type) { event_type.match(/\A[a-z]+_[a-z]+\z/i) }
 
               expect(registry.managers_of_event_condition(condition)).to contain_exactly(
                 first_manager,
                 second_manager
               )
 
-              condition = -> (event_type) { event_type == 'first_event' }
+              condition = ->(event_type) { event_type == 'first_event' }
 
               expect(registry.managers_of_event_condition(condition)).to contain_exactly(
                 first_manager
               )
 
-              condition = -> (event_type) { event_type == 'second_event' }
+              condition = ->(event_type) { event_type == 'second_event' }
 
               expect(registry.managers_of_event_condition(condition)).to contain_exactly(
                 second_manager
@@ -305,7 +305,7 @@ describe EvilEvents::Core::Events::ManagerRegistry do
 
           describe '#manager_of_event_condition' do
             it 'returns an empty collection' do
-              expect(registry.managers_of_event_condition(proc{})).to eq([])
+              expect(registry.managers_of_event_condition(proc {})).to eq([])
             end
           end
         end

--- a/spec/units/evil_events/core/events/manager_registry_spec.rb
+++ b/spec/units/evil_events/core/events/manager_registry_spec.rb
@@ -205,51 +205,108 @@ describe EvilEvents::Core::Events::ManagerRegistry do
         end
       end
 
-      describe '#manager_of_event' do
+      describe 'fetching event manager objects' do
         context 'when registry has manager of required event' do
           before do
             registry.register(first_manager)
             registry.register(second_manager)
           end
 
-          it 'returns manager of required event by event class' do
-            expect(registry.manager_of_event(first_event_class)).to  eq(first_manager)
-            expect(registry.manager_of_event(second_event_class)).to eq(second_manager)
+          describe '#manager_of_event' do
+            it 'returns manager of required event by event class' do
+              expect(registry.manager_of_event(first_event_class)).to  eq(first_manager)
+              expect(registry.manager_of_event(second_event_class)).to eq(second_manager)
+            end
+          end
+
+          describe '#manager_of_event_type' do
+            it 'returns manager of required event by event type alias' do
+              expect(registry.manager_of_event_type(first_event_class.type)).to eq(
+                first_manager
+              )
+
+              expect(registry.manager_of_event_type(second_event_class.type)).to eq(
+                second_manager
+              )
+            end
+          end
+
+          describe '#managers_of_event_pattern' do
+            it 'returns manager of required event by type alias regexp' do
+              first_event_pattern = /\Afirst_event\z/
+
+              expect(registry.managers_of_event_pattern(first_event_pattern)).to contain_exactly(
+                first_manager
+              )
+
+              second_event_pattern = /\Asecond_event\z/
+
+              expect(registry.managers_of_event_pattern(second_event_pattern)).to contain_exactly(
+                second_manager
+              )
+
+              all_in_pattern = /.+/
+
+              expect(registry.managers_of_event_pattern(all_in_pattern)).to contain_exactly(
+                first_manager,
+                second_manager
+              )
+            end
+          end
+
+          describe '#managers_of_event_condition' do
+            it 'returns a list of managers which aliases has passed required condition (proc)' do
+              condition = -> (event_type) { event_type.match(/\A[a-z]+_[a-z]+\z/i) }
+
+              expect(registry.managers_of_event_condition(condition)).to contain_exactly(
+                first_manager,
+                second_manager
+              )
+
+              condition = -> (event_type) { event_type == 'first_event' }
+
+              expect(registry.managers_of_event_condition(condition)).to contain_exactly(
+                first_manager
+              )
+
+              condition = -> (event_type) { event_type == 'second_event' }
+
+              expect(registry.managers_of_event_condition(condition)).to contain_exactly(
+                second_manager
+              )
+            end
           end
         end
 
         context 'when registry doesnt have manager of required event' do
-          it 'fails with appropriate error' do
-            expect { registry.manager_of_event(first_event_class) }.to(
-              raise_error(described_class::NonManagedEventClassError)
-            )
-          end
-        end
-      end
-
-      describe '#manager_of_event_type' do
-        context 'when registry has manager of required event type' do
-          before do
-            registry.register(first_manager)
-            registry.register(second_manager)
+          describe '#manager_of_event' do
+            it 'fails with appropriate error' do
+              expect { registry.manager_of_event(first_event_class) }.to(
+                raise_error(described_class::NonManagedEventClassError)
+              )
+            end
           end
 
-          it 'returns manager of required event by event type alias' do
-            expect(registry.manager_of_event_type(first_event_class.type)).to eq(
-              first_manager
-            )
-
-            expect(registry.manager_of_event_type(second_event_class.type)).to eq(
-              second_manager
-            )
+          describe '#manager_of_event_type' do
+            it 'fails with appropirated error' do
+              expect { registry.manager_of_event_type('test_event') }.to(
+                raise_error(described_class::NonManagedEventClassError)
+              )
+            end
           end
-        end
 
-        context 'when registry hasnt manager of required event type' do
-          it 'fails with appropirated error' do
-            expect { registry.manager_of_event_type('test_event') }.to(
-              raise_error(described_class::NonManagedEventClassError)
-            )
+          describe '#managers_of_event_pattern' do
+            it 'fails with appropriate error' do
+              expect(registry.managers_of_event_pattern(/\Afirst_event\z/)).to   eq([])
+              expect(registry.managers_of_event_pattern(/\Asecond_event\z/)).to  eq([])
+              expect(registry.managers_of_event_pattern(/\A.+\z/)).to eq([])
+            end
+          end
+
+          describe '#manager_of_event_condition' do
+            it 'returns an empty collection' do
+              expect(registry.managers_of_event_condition(proc{})).to eq([])
+            end
           end
         end
       end

--- a/spec/units/evil_events/core/system/event_manager_spec.rb
+++ b/spec/units/evil_events/core/system/event_manager_spec.rb
@@ -5,8 +5,8 @@ describe EvilEvents::Core::System::EventManager, :stub_event_system do
   let(:event_manager)    { described_class.new }
   let(:manager_registry) { event_manager.manager_registry }
 
-  let(:event_class)         { build_abstract_event_class('test') }
-  let(:another_event_class) { build_abstract_event_class('another_test') }
+  let(:event_class)         { build_abstract_event_class('test_event') }
+  let(:another_event_class) { build_abstract_event_class('another_test_event') }
 
   describe '#manager_registry' do
     it 'returns an instance of the corresponding logical element with appropriate initial state' do
@@ -205,53 +205,120 @@ describe EvilEvents::Core::System::EventManager, :stub_event_system do
     end
   end
 
-  describe 'subscriptions' do
-    describe '#observe' do
-      context 'when required event class is registered' do
-        before { event_manager.register_event_class(event_class) }
+  describe 'subscription' do
+    describe 'subscribe to concrete event' do
+      describe '#observe' do
+        context 'when required event class is registered' do
+          before { event_manager.register_event_class(event_class) }
 
-        it 'subscribes an object to the required event' do
-          manager = manager_registry.manager_of_event(event_class)
-          subscriber = proc {}
-          delegator  = :invoke
+          it 'subscribes an object to the required event' do
+            manager = manager_registry.manager_of_event(event_class)
+            subscriber, delegator = (proc {}), gen_symb(only_letters: true)
 
-          expect(manager.subscribers.registered?(subscriber)).to eq(false)
-          event_manager.observe(event_class, subscriber, :invoke)
-          expect(manager.subscribers.registered?(subscriber)).to eq(true)
-          expect(manager.subscribers.wrapper_of(subscriber).delegator).to eq(delegator)
+            event_manager.observe(event_class, subscriber, delegator)
+
+            expect(manager.subscribers.registered?(subscriber)).to eq(true)
+            expect(manager.subscribers.wrapper_of(subscriber).delegator).to eq(delegator)
+          end
+        end
+
+        context 'when required event class is not registered' do
+          it 'fails with corresponding error' do
+            expect do
+              event_manager.observe(event_class, double, :call)
+            end.to raise_error(EvilEvents::Core::Events::ManagerRegistry::NonManagedEventClassError)
+          end
         end
       end
 
-      context 'when required event class is not registered' do
-        it 'fails with corresponding error' do
-          expect do
-            event_manager.observe(event_class, double, :call)
-          end.to raise_error(EvilEvents::Core::Events::ManagerRegistry::NonManagedEventClassError)
+      describe '#raw_observe' do
+        context 'when required event class is registered' do
+          before { event_manager.register_event_class(event_class) }
+
+          it 'subscribes an object to the required event' do
+            manager = manager_registry.manager_of_event(event_class)
+            subscriber, delegator = (proc {}), gen_symb(only_letters: true)
+
+            event_manager.raw_observe(event_class.type, subscriber, delegator)
+
+            expect(manager.subscribers.registered?(subscriber)).to eq(true)
+            expect(manager.subscribers.wrapper_of(subscriber).delegator).to eq(delegator)
+          end
+        end
+
+        context 'when required event class is not registered' do
+          it 'fails with corresponding error' do
+            expect do
+              event_manager.raw_observe(event_class.type, double, :call)
+            end.to raise_error(EvilEvents::Core::Events::ManagerRegistry::NonManagedEventClassError)
+          end
         end
       end
     end
 
-    describe '#raw_observe' do
-      context 'when required event class is registered' do
-        before { event_manager.register_event_class(event_class) }
+    describe 'subscribe to the list of events' do
+      let(:first_manager)  { manager_registry.manager_of_event(event_class) }
+      let(:second_manager) { manager_registry.manager_of_event(another_event_class) }
 
-        it 'subscribes an object to the required event' do
-          manager = manager_registry.manager_of_event(event_class)
-          subscriber = proc {}
-          delegator  = :invoke
+      before do
+        event_manager.register_event_class(event_class)
+        event_manager.register_event_class(another_event_class)
+      end
 
-          expect(manager.subscribers.registered?(subscriber)).to eq(false)
-          event_manager.raw_observe(event_class.type, subscriber, :invoke)
-          expect(manager.subscribers.registered?(subscriber)).to eq(true)
-          expect(manager.subscribers.wrapper_of(subscriber).delegator).to eq(delegator)
+      describe '#observe_list' do
+        it 'subscribes an object to events whose alias is comparable with a pattern' do
+          subscriber, delegator = (-> (event) {}), gen_symb(only_letters: true)
+
+          pattern = /#{gen_str}/ # no matches
+          event_manager.observe_list(pattern, subscriber, delegator)
+
+          expect(first_manager.subscribers.registered?(subscriber)).to eq(false)
+          expect(second_manager.subscribers.registered?(subscriber)).to eq(false)
+
+          pattern = /\Atest_event\z/ # matches with test_event (event_class)
+          event_manager.observe_list(pattern, subscriber, delegator)
+
+          expect(first_manager.subscribers.registered?(subscriber)).to eq(true)
+          expect(first_manager.subscribers.wrapper_of(subscriber).delegator).to eq(delegator)
+          expect(second_manager.subscribers.registered?(subscriber)).to eq(false)
+
+          pattern = /.+/ # matches with all
+          event_manager.observe_list(pattern, subscriber, delegator)
+
+          expect(first_manager.subscribers.registered?(subscriber)).to eq(true)
+          expect(second_manager.subscribers.registered?(subscriber)).to eq(true)
+          expect(first_manager.subscribers.wrapper_of(subscriber).delegator).to eq(delegator)
+          expect(second_manager.subscribers.wrapper_of(subscriber).delegator).to eq(delegator)
         end
       end
 
-      context 'when required event class is not registered' do
-        it 'fails with corresponding error' do
-          expect do
-            event_manager.raw_observe(event_class.type, double, :call)
-          end.to raise_error(EvilEvents::Core::Events::ManagerRegistry::NonManagedEventClassError)
+      describe '#conditional_observe' do
+        specify 'condition of alias isnt false/nil ==> subscribes an object to this event' do
+          subscriber, delegator = (-> (event) {}), gen_symb(only_letters: true)
+
+          # fail condition => doesnt register
+          condition = -> (event_type) { false }
+          event_manager.conditional_observe(condition, subscriber, delegator)
+
+          expect(first_manager.subscribers.registered?(subscriber)).to eq(false)
+          expect(second_manager.subscribers.registered?(subscriber)).to eq(false)
+
+          # true for another_event_class => subscribes on this
+          condition = -> (event_type) { event_type == 'another_test_event' }
+          event_manager.conditional_observe(condition, subscriber, delegator)
+
+          expect(first_manager.subscribers.registered?(subscriber)).to eq(false)
+          expect(second_manager.subscribers.registered?(subscriber)).to eq(true)
+          expect(second_manager.subscribers.wrapper_of(subscriber).delegator).to eq(delegator)
+
+          # true for all => subscribes on all
+          condition = -> (event_type) { event_type.match(/.+/) }
+          event_manager.conditional_observe(condition, subscriber, delegator)
+
+          expect(first_manager.subscribers.registered?(subscriber)).to eq(true)
+          expect(second_manager.subscribers.registered?(subscriber)).to eq(true)
+          expect(first_manager.subscribers.wrapper_of(subscriber).delegator).to eq(delegator)
+          expect(second_manager.subscribers.wrapper_of(subscriber).delegator).to eq(delegator)
         end
       end
     end

--- a/spec/units/evil_events/core/system/event_manager_spec.rb
+++ b/spec/units/evil_events/core/system/event_manager_spec.rb
@@ -267,7 +267,7 @@ describe EvilEvents::Core::System::EventManager, :stub_event_system do
 
       describe '#observe_list' do
         it 'subscribes an object to events whose alias is comparable with a pattern' do
-          subscriber, delegator = (-> (event) {}), gen_symb(only_letters: true)
+          subscriber, delegator = (->(event) {}), gen_symb(only_letters: true)
 
           pattern = /#{gen_str}/ # no matches
           event_manager.observe_list(pattern, subscriber, delegator)
@@ -294,17 +294,17 @@ describe EvilEvents::Core::System::EventManager, :stub_event_system do
 
       describe '#conditional_observe' do
         specify 'condition of alias isnt false/nil ==> subscribes an object to this event' do
-          subscriber, delegator = (-> (event) {}), gen_symb(only_letters: true)
+          subscriber, delegator = (->(event) {}), gen_symb(only_letters: true)
 
           # fail condition => doesnt register
-          condition = -> (event_type) { false }
+          condition = ->(_event_type) { false }
           event_manager.conditional_observe(condition, subscriber, delegator)
 
           expect(first_manager.subscribers.registered?(subscriber)).to eq(false)
           expect(second_manager.subscribers.registered?(subscriber)).to eq(false)
 
           # true for another_event_class => subscribes on this
-          condition = -> (event_type) { event_type == 'another_test_event' }
+          condition = ->(event_type) { event_type == 'another_test_event' }
           event_manager.conditional_observe(condition, subscriber, delegator)
 
           expect(first_manager.subscribers.registered?(subscriber)).to eq(false)
@@ -312,7 +312,7 @@ describe EvilEvents::Core::System::EventManager, :stub_event_system do
           expect(second_manager.subscribers.wrapper_of(subscriber).delegator).to eq(delegator)
 
           # true for all => subscribes on all
-          condition = -> (event_type) { event_type.match(/.+/) }
+          condition = ->(event_type) { event_type.match(/.+/) }
           event_manager.conditional_observe(condition, subscriber, delegator)
 
           expect(first_manager.subscribers.registered?(subscriber)).to eq(true)

--- a/spec/units/evil_events/core/system_spec.rb
+++ b/spec/units/evil_events/core/system_spec.rb
@@ -18,21 +18,24 @@ describe EvilEvents::Core::System, :stub_event_system do
       type_manager_module  = event_system.type_manager
       event_builder_module = EvilEvents::Core::System::EventBuilder
 
-      %i[emit raw_emit resolve_adapter].each do |method_name|
+      %i[emit raw_emit resolve_adapter register_adapter].each do |method_name|
         expect(broadcaster_module).to receive(method_name)
         event_system.public_send(method_name)
       end
 
       %i[
-        observe raw_observe observers register_event_class
+        observe raw_observe observe_list observers register_event_class
         unregister_event_class manager_of_event manager_of_event_type
-        resolve_event_object managed_event?
+        registered_events resolve_event_class resolve_event_object managed_event?
       ].each do |method_name|
         expect(event_manager_module).to receive(method_name)
         event_system.public_send(method_name)
       end
 
-      %i[define_event_class define_abstract_event_class].each do |method_name|
+      %i[
+        define_event_class define_abstract_event_class
+        deserialize_from_json deserialize_from_hash
+      ].each do |method_name|
         expect(event_builder_module).to receive(method_name)
         event_system.public_send(method_name)
       end

--- a/spec/units/evil_events/core/system_spec.rb
+++ b/spec/units/evil_events/core/system_spec.rb
@@ -24,7 +24,7 @@ describe EvilEvents::Core::System, :stub_event_system do
       end
 
       %i[
-        observe raw_observe observe_list observers register_event_class
+        observe raw_observe observe_list conditional_observe observers register_event_class
         unregister_event_class manager_of_event manager_of_event_type
         registered_events resolve_event_class resolve_event_object managed_event?
       ].each do |method_name|


### PR DESCRIPTION
At the moment we have two ways to subscribe to the event: event class and event type. But there is no way to subscribe to the event list. It would be nice to have this ability using:
- list of event classes
- list of event types
- list of type regexps
- combination of them

```ruby
module LittleListener
  extend EvilEvents::SubscriberMixin

  # NOTE: delegator attribute is optional

  subscribe_to UserRegistered, DepositCreated, delegator: :process_event
  subscribe_to 'deposit_rejected', 'match_lost', delegator: :call
  subscribe_to /\A.*_event\z/, delegator: :store
  # and combination of them like:
  subscribe_to UserRegistered, 'deposit_created', /\A.*_event\z/, delegator: :invoke
end
```