### PR TITLE
Fix inconsistent event system container state between specs

### DIFF
--- a/spec/integration/configuration_spec.rb
+++ b/spec/integration/configuration_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe 'Configuration', :stub_config do
+describe 'Configuration', :stub_event_system do
   specify 'configure common options' do
     null_logger = SpecSupport::NullLogger
     io_logger   = Logger.new(StringIO.new)


### PR DESCRIPTION
In start of some specs:

```ruby
[1] pry(#<RSpec::ExampleGroups::Configuration>)> EvilEvents::Application.registered_events
=> {"95295e83ef442ad04042"=>#<Class:0x00007f8d998a9d18>,
 "fb67167b175c30ca601f"=>#<Class:0x00007f8d9b2fe808>,
 "a9747171817cbd5ffb47"=>#<Class:0x00007f8d9b38fba0>,
 "07177207d36a5c9bf54c"=>#<Class:0x00007f8d9a4e2ee0>,
 "5676b2e61733dd112bda"=>#<Class:0x00007f8d9a4f31f0>,
 "b6b1ce91dd02556de820"=>#<Class:0x00007f8d9a522950>,
 "d0f10340186a440c7231"=>#<Class:0x00007f8d9a530b90>,
 "e619ca6e7ca679174b6f"=>#<Class:0x00007f8d9a553a28>,
 "3632c20bfadf92d9898a"=>#<Class:0x00007f8d9a578080>,
 "3193a9e7d64013c06fae"=>#<Class:0x00007f8d9a5ab188>,
 "7940055ebddd6e6c2457"=>#<Class:0x00007f8d9a5c82d8>,
 "b3c36e2dc8e4c48f0fac"=>#<Class:0x00007f8d9a5eb940>,
 "c38db4ff05305623c4c0"=>#<Class:0x00007f8d9a63abd0>,
 "41e7f1727609fd4076a5"=>#<Class:0x00007f8d9a644e78>,
 "c8018c2d7db3561f0b01"=>#<Class:0x00007f8d9a63c7f0>,
 "e71d07e2d48cdb695b7c"=>#<Class:0x00007f8d9a67b5b8>,
 "4883ae0de4843283becc"=>#<Class:0x00007f8d9a68bf58>,
 "fb4c65235ea05229f9a2"=>#<Class:0x00007f8d9a6b4340>,
 "2a54e774d1c3f2caadc2"=>#<Class:0x00007f8d9a6c49e8>,
 "f6136e893acaf7aae11a"=>#<Class:0x00007f8d9a6f8a68>,
 "737b1bb095f4c670e2ea"=>#<Class:0x00007f8d9a708878>}
```