### PR TITLE
XML Event Serialization

### DIFF
--- a/.jrubyrc
+++ b/.jrubyrc
@@ -1,1 +1,0 @@
-debug.fullTrace=true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -59,6 +59,9 @@ Style/EvalWithLocation:
 Style/RegexpLiteral:
   EnforcedStyle: mixed
 
+Layout/MultilineOperationIndentation:
+  Enabled: false
+
 Lint/AmbiguousRegexpLiteral:
   Enabled: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ rvm:
 - 2.4.4
 - 2.5.1
 - ruby-head
-- jruby-head
 
 sudo: false
 before_install: gem install bundler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 ### Added
-- Support for Ruby `2.2.10, `2.3.7`, `2.4.4`, `2.5.1`;
+- Support for Ruby `2.2.10`, `2.3.7`, `2.4.4`, `2.5.1`;
 - Ability to broadcast events via any registered adapter (by explicitly passed `:adapter` attribute
   in emition methods):
   - `EvilEvents::Emitter.emit('your_event_type', adapter: :your_adapter_identifier, **event_attrs)`;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,29 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 ### Added
+- Support for Ruby `2.2.10, `2.3.7`, `2.4.4`, `2.5.1`;
 - Ability to broadcast events via any registered adapter (by explicitly passed `:adapter` attribute
   in emition methods):
-  - `EvilEvents::Emitter.emit('your_event_type', adapter: :your_adapter_identifier, **event_attrs)`
-  - `YourEventClass.emit!(adapter: :your_adapter_identifier, **event_attrs)`
-  - `your_event.emit!(adapter: :your_adapter_identifier)`
+  - `EvilEvents::Emitter.emit('your_event_type', adapter: :your_adapter_identifier, **event_attrs)`;
+  - `YourEventClass.emit!(adapter: :your_adapter_identifier, **event_attrs)`;
+  - `your_event.emit!(adapter: :your_adapter_identifier)`;
+- Added XML event serialization format:
+  - `EvilEvents::Serializer.load_from_xml(event)` - returns an event object;
+  - `your_event.serialize_to_xml` - returns xml string;
+  - `your_event.dump_to_xml` - returns xml string (`serialize_to_xml` alias);
+- Added an ability to check an event object similarity:
+  - `your_event.similar_to?(another_event)` - `returns` true if `another_event` has equal id/type/metadata/paylaod
+    attributes (and interface) - otherwise returns `false`.
 
 ### Changed
-- Removed EvilEvents::CombinedContext class and submodules => Symbiont is used instead (symbiont-ruby).
+- Removed `EvilEvents::CombinedContext` class and submodules => `Symbiont` is used instead (gem `symbiont-ruby`);
+- Added specific serialization error classes (inherited from `EvilEvents::SerializationError`:
+  - `EvilEvents::HashSerializationError`;
+  - `EvilEvents::HashDeserializationError`;
+  - `EvilEvents::JSONSerializationError`;
+  - `EvilEvents::JSONSerializationError`;
+  - `EvilEvents::XMLSerializationError`;
+  - `EvilEvents::XMLSerializationError`.
 
 ## [0.3.1] - 2018-03-01
 ### Fixed

--- a/evil_events.gemspec
+++ b/evil_events.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'dry-container',    '~> 0.6.0'
   spec.add_dependency 'concurrent-ruby',  '~> 1.0.5'
   spec.add_dependency 'symbiont-ruby',    '~> 0.2.0'
+  spec.add_dependency 'ox',               '~> 2.9.0'
 
   spec.add_development_dependency 'coveralls',      '~> 0.8.21'
   spec.add_development_dependency 'simplecov',      '~> 0.14.1'

--- a/evil_events.gemspec
+++ b/evil_events.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'evil_events/version'
 
 Gem::Specification.new do |spec|
-  spec.required_ruby_version = '>= 2.2.7'
+  spec.required_ruby_version = '>= 2.2.10'
 
   spec.name        = 'evil_events'
   spec.version     = EvilEvents::VERSION

--- a/lib/evil_events.rb
+++ b/lib/evil_events.rb
@@ -11,6 +11,7 @@ require 'securerandom'
 require 'forwardable'
 require 'logger'
 require 'json'
+require 'ox'
 
 # @api public
 # @since 0.1.0

--- a/lib/evil_events/core/events.rb
+++ b/lib/evil_events/core/events.rb
@@ -8,6 +8,7 @@ module EvilEvents::Core
     require_relative 'events/serializers/base'
     require_relative 'events/serializers/hash'
     require_relative 'events/serializers/json'
+    require_relative 'events/serializers/xml'
     require_relative 'events/event_extensions/type_aliasing'
     require_relative 'events/event_extensions/payloadable'
     require_relative 'events/event_extensions/payloadable/abstract_payload'

--- a/lib/evil_events/core/events.rb
+++ b/lib/evil_events/core/events.rb
@@ -9,6 +9,7 @@ module EvilEvents::Core
     require_relative 'events/serializers/hash'
     require_relative 'events/serializers/json'
     require_relative 'events/serializers/xml'
+    require_relative 'events/serializers/xml/event_serialization_state'
     require_relative 'events/event_extensions/type_aliasing'
     require_relative 'events/event_extensions/payloadable'
     require_relative 'events/event_extensions/payloadable/abstract_payload'

--- a/lib/evil_events/core/events/event_extensions/class_signature.rb
+++ b/lib/evil_events/core/events/event_extensions/class_signature.rb
@@ -17,6 +17,19 @@ module EvilEvents::Core::Events::EventExtensions
       end
     end
 
+    # @param another_event [Object]
+    # @return [Boolean]
+    #
+    # @since 0.4.0
+    def similar_to?(another_event)
+      id       == another_event.id &&
+      type     == another_event.type &&
+      payload  == another_event.payload &&
+      metadata == another_event.metadata
+    rescue NoMethodError
+      false
+    end
+
     # @since 0.2.0
     module ClassMethods
       # @return [Signature]

--- a/lib/evil_events/core/events/event_extensions/class_signature/equalizer.rb
+++ b/lib/evil_events/core/events/event_extensions/class_signature/equalizer.rb
@@ -69,14 +69,12 @@ module EvilEvents::Core::Events::EventExtensions::ClassSignature
     #
     # @since 0.2.0
     def similar_signatures?
-      # rubocop:disable Layout/MultilineOperationIndentation
       equal_type_alias? &&
       equal_class?      &&
       equal_payload?    &&
       equal_metadata?   &&
       equal_delegator?  &&
       equal_adapter?
-      # rubocop:enable Layout/MultilineOperationIndentation
     end
   end
 end

--- a/lib/evil_events/core/events/event_extensions/serializable.rb
+++ b/lib/evil_events/core/events/event_extensions/serializable.rb
@@ -19,5 +19,13 @@ module EvilEvents::Core::Events::EventExtensions
       EvilEvents::Core::Events::Serializers[:json].serialize(self)
     end
     alias_method :dump_to_json, :serialize_to_json
+
+    # @return [String]
+    #
+    # @since 0.4.0
+    def serialize_to_xml
+      EvilEvents::Core::Events::Serializers[:xml].serialize(self)
+    end
+    alias_method :dump_to_xml, :serialize_to_xml
   end
 end

--- a/lib/evil_events/core/events/serializers/hash.rb
+++ b/lib/evil_events/core/events/serializers/hash.rb
@@ -9,13 +9,13 @@ class EvilEvents::Core::Events::Serializers
 
     class << self
       # @param event [EvilEvents::Core::Events::AbstractEvent]
-      # @raise [EvilEvents::SerializationError]
+      # @raise [EvilEvents::HashSerializationError]
       # @return [::Hash]
       #
       # @since 0.1.0
       def serialize(event)
         unless event.is_a?(EvilEvents::Core::Events::AbstractEvent)
-          raise EvilEvents::SerializationError
+          raise EvilEvents::HashSerializationError
         end
 
         {

--- a/lib/evil_events/core/events/serializers/hash.rb
+++ b/lib/evil_events/core/events/serializers/hash.rb
@@ -31,21 +31,29 @@ class EvilEvents::Core::Events::Serializers
       # rubocop:disable Metrics/PerceivedComplexity
 
       # @param hash [::Hash]
-      # @raise [EvilEvents::DeserializationError]
+      # @raise [EvilEvents::HashDeserializationError]
       # @return [EvilEvents::Core::Events::AbstractEvent]
       #
       # @since 0.1.0
       def deserialize(hash)
-        raise EvilEvents::DeserializationError unless hash.is_a?(::Hash)
+        raise EvilEvents::HashDeserializationError unless hash.is_a?(::Hash)
 
         event_id       = hash[:id]       || hash['id']
         event_type     = hash[:type]     || hash['type']
         event_payload  = hash[:payload]  || hash['payload']
         event_metadata = hash[:metadata] || hash['metadata']
 
-        raise EvilEvents::DeserializationError unless event_type && event_payload && event_metadata
-        raise EvilEvents::DeserializationError unless event_payload.is_a?(::Hash)
-        raise EvilEvents::DeserializationError unless event_metadata.is_a?(::Hash)
+        unless event_type && event_payload && event_metadata
+          raise EvilEvents::HashDeserializationError
+        end
+
+        unless event_payload.is_a?(::Hash)
+          raise EvilEvents::HashDeserializationError
+        end
+
+        unless event_metadata.is_a?(::Hash)
+          raise EvilEvents::HashDeserializationError
+        end
 
         restore_event_instance(
           type:     event_type,

--- a/lib/evil_events/core/events/serializers/hash.rb
+++ b/lib/evil_events/core/events/serializers/hash.rb
@@ -47,13 +47,8 @@ class EvilEvents::Core::Events::Serializers
           raise EvilEvents::HashDeserializationError
         end
 
-        unless event_payload.is_a?(::Hash)
-          raise EvilEvents::HashDeserializationError
-        end
-
-        unless event_metadata.is_a?(::Hash)
-          raise EvilEvents::HashDeserializationError
-        end
+        raise EvilEvents::HashDeserializationError unless event_payload.is_a?(::Hash)
+        raise EvilEvents::HashDeserializationError unless event_metadata.is_a?(::Hash)
 
         restore_event_instance(
           type:     event_type,

--- a/lib/evil_events/core/events/serializers/json.rb
+++ b/lib/evil_events/core/events/serializers/json.rb
@@ -27,12 +27,12 @@ class EvilEvents::Core::Events::Serializers
       end
 
       # @param json [String]
-      # @raise [EvilEvents::DeserializationError]
+      # @raise [EvilEvents::JSONDeserializationError]
       # @return [EvilEvents::Core::Events::AbstractEvent]
       #
       # @since 0.1.0
       def deserialize(json)
-        raise EvilEvents::DeserializationError unless json.is_a?(String)
+        raise EvilEvents::JSONDeserializationError unless json.is_a?(String)
 
         begin
           json_hash      = ::JSON.parse(json, symbolize_names: true)
@@ -42,10 +42,10 @@ class EvilEvents::Core::Events::Serializers
           event_metadata = json_hash[:metadata]
 
           unless event_type && event_payload && event_metadata
-            raise EvilEvents::DeserializationError
+            raise EvilEvents::JSONDeserializationError
           end
         rescue ::JSON::ParserError
-          raise EvilEvents::DeserializationError
+          raise EvilEvents::JSONDeserializationError
         end
 
         restore_event_instance(

--- a/lib/evil_events/core/events/serializers/json.rb
+++ b/lib/evil_events/core/events/serializers/json.rb
@@ -9,13 +9,13 @@ class EvilEvents::Core::Events::Serializers
 
     class << self
       # @param event [EvilEvents::Core::Events::AbstractEvent]
-      # @raise [EvilEvents::SerializationError]
-      # @return [::Hash]
+      # @raise [EvilEvents::JSONSerializationError]
+      # @return [String]
       #
       # @since 0.1.0
       def serialize(event)
         unless event.is_a?(EvilEvents::Core::Events::AbstractEvent)
-          raise EvilEvents::SerializationError
+          raise EvilEvents::JSONSerializationError
         end
 
         ::JSON.generate(

--- a/lib/evil_events/core/events/serializers/xml.rb
+++ b/lib/evil_events/core/events/serializers/xml.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class EvilEvents::Core::Events::Serializers
+  module XML
+    extend Base
+
+    # @param event [EvilEvents::Core::Events::AbstractEvent]
+    # @raise [EvilEvents::JSONSerializaionError]
+    # @return [String]
+    #
+    # @api private
+    # @since 0.4.0
+    def serialize(event)
+      unless event.is_a?(EvilEvents::Core::Events::AbstractEvent)
+        raise EvilEvents::JSONSerializationError
+      end
+
+
+    end
+
+    # @param xml [String]
+    # @return [EvilEvents::Core::Events::AbstractEvent]
+    #
+    # @api private
+    # @since 0.4.0
+    def deserialize(xml)
+    end
+  end
+
+  register(:xml) { XML }
+end

--- a/lib/evil_events/core/events/serializers/xml.rb
+++ b/lib/evil_events/core/events/serializers/xml.rb
@@ -19,7 +19,7 @@ class EvilEvents::Core::Events::Serializers
           raise EvilEvents::XMLSerializationError
         end
 
-        Ox.dump(EventSerializationProxy.new(event))
+        Ox.dump(EventSerializationState.new(event))
       end
 
       # @param xml [String]
@@ -31,18 +31,16 @@ class EvilEvents::Core::Events::Serializers
         raise EvilEvents::XMLDeserializationError unless xml.is_a?(String)
 
         begin
-          serialization_proxy = Ox.parse_obj(xml)
-        rescue Ox::Error => error
-          raise EvilEvents::XMLDeserializationError, error.message
-        rescue NoMethodError
+          event_serialization_state = Ox.parse_obj(xml)
+        rescue Ox::Error, NoMethodError, ArgumentError
           raise EvilEvents::XMLDeserializationError
         end
 
         restore_event_instance(
-          id:       serialization_proxy.id,
-          type:     serialization_proxy.type,
-          payload:  serialization_proxy.payload,
-          metadata: serialization_proxy.metadata
+          id:       event_serialization_state.id,
+          type:     event_serialization_state.type,
+          payload:  event_serialization_state.payload,
+          metadata: event_serialization_state.metadata
         )
       end
     end

--- a/lib/evil_events/core/events/serializers/xml.rb
+++ b/lib/evil_events/core/events/serializers/xml.rb
@@ -1,29 +1,50 @@
 # frozen_string_literal: true
 
 class EvilEvents::Core::Events::Serializers
+  # @api private
+  # @since 0.4.0
   module XML
+    # @since 0.4.0
     extend Base
 
-    # @param event [EvilEvents::Core::Events::AbstractEvent]
-    # @raise [EvilEvents::JSONSerializaionError]
-    # @return [String]
-    #
-    # @api private
-    # @since 0.4.0
-    def serialize(event)
-      unless event.is_a?(EvilEvents::Core::Events::AbstractEvent)
-        raise EvilEvents::JSONSerializationError
+    class << self
+      # @param event [EvilEvents::Core::Events::AbstractEvent]
+      # @raise [EvilEvents::XMLSerializationError]
+      # @return [String]
+      #
+      # @api private
+      # @since 0.4.0
+      def serialize(event)
+        unless event.is_a?(EvilEvents::Core::Events::AbstractEvent)
+          raise EvilEvents::XMLSerializationError
+        end
+
+        Ox.dump(EventSerializationProxy.new(event))
       end
 
+      # @param xml [String]
+      # @return [EvilEvents::Core::Events::AbstractEvent]
+      #
+      # @api private
+      # @since 0.4.0
+      def deserialize(xml)
+        raise EvilEvents::XMLDeserializationError unless xml.is_a?(String)
 
-    end
+        begin
+          serialization_proxy = Ox.parse_obj(xml)
+        rescue Ox::Error => error
+          raise EvilEvents::XMLDeserializationError, error.message
+        rescue NoMethodError
+          raise EvilEvents::XMLDeserializationError
+        end
 
-    # @param xml [String]
-    # @return [EvilEvents::Core::Events::AbstractEvent]
-    #
-    # @api private
-    # @since 0.4.0
-    def deserialize(xml)
+        restore_event_instance(
+          id:       serialization_proxy.id,
+          type:     serialization_proxy.type,
+          payload:  serialization_proxy.payload,
+          metadata: serialization_proxy.metadata
+        )
+      end
     end
   end
 

--- a/lib/evil_events/core/events/serializers/xml/event_serialization_proxy.rb
+++ b/lib/evil_events/core/events/serializers/xml/event_serialization_proxy.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module EvilEvents::Core::Events::Serializers::Xml
+  # @api private
+  # @since 0.4.0
+  class EventSerializationProxy
+    # @return [Integer]
+    #
+    # @since 0.4.0
+    attr_reader :id
+
+    # @return [String]
+    #
+    # @since 0.4.0
+    attr_reader :type
+
+    # @return [::Hash]
+    #
+    # @since 0.4.0
+    attr_reader :payload
+
+    # @return [::Hash]
+    #
+    # @since 0.4.0
+    attr_reader :metadata
+
+
+    # @param event [EvilEvents::Core::Events::AbstractEvent]
+    #
+    # @since 0.4.0
+    def initialize(event)
+      @id       = event.id
+      @type     = event.type
+      @payload  = event.payload
+      @metadata = event.metadata
+    end
+  end
+end

--- a/lib/evil_events/core/events/serializers/xml/event_serialization_state.rb
+++ b/lib/evil_events/core/events/serializers/xml/event_serialization_state.rb
@@ -4,7 +4,7 @@ module EvilEvents::Core::Events::Serializers::XML
   # @api private
   # @since 0.4.0
   class EventSerializationState
-    # @return [Integer]
+    # @return [String,Object]
     #
     # @since 0.4.0
     attr_reader :id

--- a/lib/evil_events/core/events/serializers/xml/event_serialization_state.rb
+++ b/lib/evil_events/core/events/serializers/xml/event_serialization_state.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-module EvilEvents::Core::Events::Serializers::Xml
+module EvilEvents::Core::Events::Serializers::XML
   # @api private
   # @since 0.4.0
-  class EventSerializationProxy
+  class EventSerializationState
     # @return [Integer]
     #
     # @since 0.4.0
@@ -23,7 +23,6 @@ module EvilEvents::Core::Events::Serializers::Xml
     #
     # @since 0.4.0
     attr_reader :metadata
-
 
     # @param event [EvilEvents::Core::Events::AbstractEvent]
     #

--- a/lib/evil_events/core/system.rb
+++ b/lib/evil_events/core/system.rb
@@ -49,7 +49,8 @@ module EvilEvents::Core
                    :define_event_class,
                    :define_abstract_event_class,
                    :deserialize_from_json,
-                   :deserialize_from_hash
+                   :deserialize_from_hash,
+                   :deserialize_from_xml
 
     # @see EvilEvents::Core::System::TypeManager
     # @since 0.2.0

--- a/lib/evil_events/core/system/event_builder.rb
+++ b/lib/evil_events/core/system/event_builder.rb
@@ -37,6 +37,14 @@ class EvilEvents::Core::System
       def deserialize_from_hash(serialized_event)
         EvilEvents::Core::Events::Serializers[:hash].deserialize(serialized_event)
       end
+
+      # @param serialized_event [String]
+      # @return [EvilEvents::Core::Events::AbstractEvent]
+      #
+      # @since 0.4.0
+      def deserialize_from_xml(serialized_event)
+        EvilEvents::Core::Events::Serializers[:xml].deserialize(serialized_event)
+      end
     end
   end
 end

--- a/lib/evil_events/core/system/mock.rb
+++ b/lib/evil_events/core/system/mock.rb
@@ -92,6 +92,10 @@ class EvilEvents::Core::System
     def deserialize_from_hash(serialized_event); end
 
     # @see EvilEvents::Core::System
+    # @since 0.4.0
+    def deserialize_from_xml(serialized_event); end
+
+    # @see EvilEvents::Core::System
     # @since 0.1.0
     def managed_event?(event_class); end
 

--- a/lib/evil_events/error.rb
+++ b/lib/evil_events/error.rb
@@ -57,8 +57,20 @@ module EvilEvents
   SerializersError = Class.new(Error)
   # @since 0.3.0
   SerializationError = Class.new(SerializersError)
+  # @since 0.4.0
+  JSONSerializationError = Class.new(SerializationError)
+  # @since 0.4.0
+  XMLSerializationError = Class.new(SerializationError)
+  # @since 0.4.0
+  HashSerializationError = Class.new(SerializationError)
   # @since 0.3.0
   DeserializationError = Class.new(SerializersError)
+  # @since 0.4.0
+  JSONDeserializationError = Class.new(DeserializationError)
+  # @since 0.4.0
+  XMLDeserializationError = Class.new(DeserializationError)
+  # @since 0.4.0
+  HashDeserializationError = Class.new(DeserializationError)
 
   # NOTE: see EvilEvents::Core::Events::Notifier
   # @since 0.3.0

--- a/lib/evil_events/serializer.rb
+++ b/lib/evil_events/serializer.rb
@@ -18,6 +18,13 @@ module EvilEvents
       def load_from_hash(serialized_event)
         EvilEvents::Core::Bootstrap[:event_system].deserialize_from_hash(serialized_event)
       end
+
+      # @see EvilEvents::Core::System
+      # @api public
+      # @since 0.4.0
+      def load_from_xml(serialized_event)
+        EvilEvents::Core::Bootstrap[:event_system].deserialize_from_xml(serialized_event)
+      end
     end
   end
 end

--- a/spec/support/shared_examples/event_extensions/class_signature_interface.rb
+++ b/spec/support/shared_examples/event_extensions/class_signature_interface.rb
@@ -1,6 +1,143 @@
 # frozen_string_literal: true
 
 shared_examples 'class signature interface' do
+  describe 'instance interface' do
+    describe '#similar_to?', :stub_event_system do
+      let(:event_klass) do
+        build_event_class do
+          payload :a
+          payload :b
+          payload :c
+
+          metadata :d
+          metadata :e
+          metadata :f
+        end
+      end
+
+      let(:another_event_klass) do
+        build_event_class do
+          payload :a
+          payload :b
+          payload :c
+
+          metadata :d
+          metadata :e
+          metadata :f
+        end
+      end
+
+      let(:event_attrs) do
+        {
+          id: gen_str,
+          payload: { a: gen_int, b: gen_str, c: gen_symb },
+          metadata: { d: gen_float, e: gen_int, f: gen_str }
+        }
+      end
+
+      let(:event) do
+        event_klass.new(
+          id:       event_attrs[:id],
+          payload:  event_attrs[:payload],
+          metadata: event_attrs[:metadata]
+        )
+      end
+
+      context 'when objects has equal general event attributes' do
+        let(:similar_event) do
+          event_klass.new(
+            id:       event_attrs[:id],
+            payload:  event_attrs[:payload],
+            metadata: event_attrs[:metadata]
+          )
+        end
+
+        let(:similar_object) do
+          Struct.new(:type, :id, :payload, :metadata).new(
+            event_klass.type, *event_attrs.values_at(:id, :payload, :metadata)
+          )
+        end
+
+        it 'returns true' do
+          # event similarity
+          expect(event.similar_to?(similar_event)).to eq(true)
+          expect(similar_event.similar_to?(event)).to eq(true)
+
+          # object similarity
+          expect(event.similar_to?(similar_object)).to         eq(true)
+          expect(similar_event.similar_to?(similar_object)).to eq(true)
+        end
+      end
+
+      context 'when object has no equal general event attributes' do
+        it 'returns false' do
+          non_similar_event = event_klass.new(
+            id: gen_str,
+            payload: { a: gen_int, b: gen_str, c: gen_symb },
+            metadata: { d: gen_float, e: gen_int, f: gen_str }
+          )
+
+          non_similar_id = event_klass.new(
+            payload:  event_attrs[:payload],
+            metadata: event_attrs[:metadata]
+          )
+
+          non_similar_payload = event_klass.new(
+            id:       event_attrs[:id],
+            payload:  { a: gen_symb, b: gen_int, c: gen_str },
+            metadata: event_attrs[:metadata]
+          )
+
+          non_similar_metadata = event_klass.new(
+            id:       event_attrs[:id],
+            payload:  event_attrs[:payload],
+            metadata: { d: gen_float, e: gen_int, f: gen_str }
+          )
+
+          non_similar_type = another_event_klass.new(
+            id:       event_attrs[:id],
+            payload:  event_attrs[:payload],
+            metadata: event_attrs[:metadata]
+          )
+
+          expect(event.similar_to?(non_similar_type)).to     eq(false)
+          expect(event.similar_to?(non_similar_event)).to    eq(false)
+          expect(event.similar_to?(non_similar_id)).to       eq(false)
+          expect(event.similar_to?(non_similar_payload)).to  eq(false)
+          expect(event.similar_to?(non_similar_metadata)).to eq(false)
+        end
+      end
+
+      context 'when similar object has non-equal attribute interface' do
+        it 'returns false' do
+          non_similar_id = Struct.new(:type, :payload, :metadata).new(
+            event_klass.type, *event_attrs.values_at(:payload, :metadata)
+          )
+
+          non_similar_payload = Struct.new(:type, :id, :metadata).new(
+            event_klass.type, *event_attrs.values_at(:id, :metadata)
+          )
+
+          non_similar_metadata = Struct.new(:type, :id, :payload).new(
+            event_klass.type, *event_attrs.values_at(:id, :payload)
+          )
+
+          non_similar_type = Struct.new(:id, :payload, :metadata).new(
+            *event_attrs.values_at(:id, :payload, :metadata)
+          )
+
+          non_similar_object = Struct.new(gen_symb, gen_symb).new(gen_int, gen_str)
+
+          expect(event.similar_to?(non_similar_id)).to       eq(false)
+          expect(event.similar_to?(non_similar_payload)).to  eq(false)
+          expect(event.similar_to?(non_similar_metadata)).to eq(false)
+          expect(event.similar_to?(non_similar_type)).to     eq(false)
+          expect(event.similar_to?(non_similar_object)).to   eq(false)
+        end
+      end
+    end
+  end
+
   describe 'class signature proxy interface' do
     describe '__creation_strategy__' do
       specify '.__creation_strategy__ accessor' do

--- a/spec/support/shared_examples/event_extensions/serializable_interface.rb
+++ b/spec/support/shared_examples/event_extensions/serializable_interface.rb
@@ -26,5 +26,6 @@ shared_examples 'serializable interface' do
 
     it_behaves_like 'valid serialization logic', :hash, :serialize_to_hash
     it_behaves_like 'valid serialization logic', :json, :serialize_to_json
+    it_behaves_like 'valid serialization logic', :xml,  :serialize_to_xml
   end
 end

--- a/spec/support/spec_support/fake_data_generator.rb
+++ b/spec/support/spec_support/fake_data_generator.rb
@@ -101,7 +101,9 @@ module SpecSupport::FakeDataGenerator
     -> {}
   end
 
-  # TODO: .gen_hash() method
+  def gen_all
+    FACTORY_METHODS.map { |generator| send(generator) }.shuffle!
+  end
 
   def gen_event_attr_type(constraint = :primitive)
     type_name       = EVENT_ATTR_TYPES[constraint].sample

--- a/spec/units/evil_events/core/broadcasting/emitter_spec.rb
+++ b/spec/units/evil_events/core/broadcasting/emitter_spec.rb
@@ -5,10 +5,6 @@ describe EvilEvents::Core::Broadcasting::Emitter, :stub_event_system do
 
   let(:emitter) { described_class.new }
 
-  # TODO: add specs for explicit adapter identifier
-  #   (see EvilEvents::Core::Events::Broadcasting::Emitter/AdapterProxy)
-  #   !!dont forget about activity logging!!
-
   describe 'event handling logic' do
     let(:silent_output)      { StringIO.new }
     let(:silent_logger)      { ::Logger.new(silent_output) }

--- a/spec/units/evil_events/core/events/serializers/hash_spec.rb
+++ b/spec/units/evil_events/core/events/serializers/hash_spec.rb
@@ -196,13 +196,36 @@ describe EvilEvents::Core::Events::Serializers::Hash, :stub_event_system do
         end
 
         context 'when passed hash represents existing event but has incompatible payload' do
-          let(:incompatible_hash) do
+          let(:incompatible_ivar_types) do
+            [
+              { type: nil, payload: nil, metadata: nil },
+              { type: nil, payload: nil, metadata: {} },
+              { type: nil, payload: {}, metadata: nil },
+              { type: nil, payload: {}, metadata: {} },
+              { type: 'spec_worked', payload: nil, metadata: {} },
+              { type: 'spec_worked', payload: {}, metadata: double },
+              { type: 'spec_worked', payload: double, metadata: {} },
+              { type: 'spec_worked', payload: {}, metadata: nil },
+              { type: 'spec_worked', payload: nil, metadata: nil },
+              { type: 'spec_worked', payload: double, metadata: double },
+              { type: 'spec_worked', payload: double, metadata: nil },
+              { type: 'spec_worked', payload: nil, metadata: double }
+            ]
+          end
+
+          let(:incompatible_event_attributes) do
             { type: 'spec_worked', payload: {}, metadata: {} }
           end
 
           it 'fails with payload constructor error' do
-            expect { described_class.deserialize(incompatible_hash) }.to(
-              raise_error(Dry::Struct::Error)
+            incompatible_ivar_types.each do |incompatible_hash|
+              expect { described_class.deserialize(incompatible_hash) }.to raise_error(
+                EvilEvents::HashDeserializationError
+              )
+            end
+
+            expect { described_class.deserialize(incompatible_event_attributes) }.to raise_error(
+              Dry::Struct::Error
             )
           end
         end
@@ -218,7 +241,7 @@ describe EvilEvents::Core::Events::Serializers::Hash, :stub_event_system do
             { id: gen_str }
           ].each do |serialized_event|
             expect { described_class.deserialize(serialized_event) }.to(
-              raise_error(EvilEvents::DeserializationError)
+              raise_error(EvilEvents::HashDeserializationError)
             )
           end
         end
@@ -230,7 +253,7 @@ describe EvilEvents::Core::Events::Serializers::Hash, :stub_event_system do
 
       it 'fails with appropriate deserialization error' do
         expect { deserialization }.to(
-          raise_error(EvilEvents::DeserializationError)
+          raise_error(EvilEvents::HashDeserializationError)
         )
       end
     end

--- a/spec/units/evil_events/core/events/serializers/hash_spec.rb
+++ b/spec/units/evil_events/core/events/serializers/hash_spec.rb
@@ -65,7 +65,9 @@ describe EvilEvents::Core::Events::Serializers::Hash, :stub_event_system do
       let(:serialization) { described_class.serialize(double) }
 
       it 'fails with appropriate serialization exception' do
-        expect { serialization }.to raise_error(EvilEvents::SerializationError)
+        expect { serialization }.to raise_error(
+          EvilEvents::HashSerializationError
+        )
       end
     end
   end

--- a/spec/units/evil_events/core/events/serializers/json_spec.rb
+++ b/spec/units/evil_events/core/events/serializers/json_spec.rb
@@ -4,7 +4,7 @@ describe EvilEvents::Core::Events::Serializers::JSON, :stub_event_system do
   include_context 'event system'
 
   describe '.serialize' do
-    context 'when receied object is an event instance' do
+    context 'when received object is an event instance' do
       it 'returns json representation of event object with appropriate format' do
         keks_signed_in_attrs = {
           id: gen_str,
@@ -122,10 +122,10 @@ describe EvilEvents::Core::Events::Serializers::JSON, :stub_event_system do
           }
 
           event = described_class.deserialize(::JSON.generate(serialized_event))
-          expect(event).to be_a(keks_lost_event_klass)
-          expect(event.id).to eq(EvilEvents::Core::Events::EventFactory::UNDEFINED_EVENT_ID)
-          expect(event.type).to eq(keks_lost_event_klass.type)
-          expect(event.payload).to match(serialized_event[:payload])
+          expect(event).to          be_a(keks_lost_event_klass)
+          expect(event.id).to       eq(EvilEvents::Core::Events::EventFactory::UNDEFINED_EVENT_ID)
+          expect(event.type).to     eq(keks_lost_event_klass.type)
+          expect(event.payload).to  match(serialized_event[:payload])
           expect(event.metadata).to match(serialized_event[:metadata])
 
           serialized_event = {
@@ -150,7 +150,7 @@ describe EvilEvents::Core::Events::Serializers::JSON, :stub_event_system do
         end
       end
 
-      context 'when passed json string represents non-existed event' do
+      context 'when passed json string represents non-existing event' do
         let(:incompatible_json) do
           ::JSON.generate(
             type: gen_str,
@@ -161,14 +161,16 @@ describe EvilEvents::Core::Events::Serializers::JSON, :stub_event_system do
         end
 
         it 'fails with non-managed-event-class error' do
-          expect { described_class.deserialize(incompatible_json) }.to(
-            raise_error(EvilEvents::NonManagedEventClassError)
+          expect { described_class.deserialize(incompatible_json) }.to raise_error(
+            EvilEvents::NonManagedEventClassError
           )
         end
       end
 
-      context 'when passed json string represents existing event but has incompatible payload' do
-        let(:incompatible_json) { ::JSON.generate(type: 'keks_lost', payload: {}, metadata: {}) }
+      context 'when passed json string represents existing event but has incompatible attrs' do
+        let(:incompatible_json) do
+          ::JSON.generate(type: 'keks_lost', payload: {}, metadata: {})
+        end
 
         it 'fails with payload constructor error' do
           expect { described_class.deserialize(incompatible_json) }.to(
@@ -187,7 +189,7 @@ describe EvilEvents::Core::Events::Serializers::JSON, :stub_event_system do
             { id: gen_str }.to_json
           ].each do |serialized_event|
             expect { described_class.deserialize(serialized_event) }.to(
-              raise_error(EvilEvents::DeserializationError)
+              raise_error(EvilEvents::JSONDeserializationError)
             )
           end
         end
@@ -198,7 +200,7 @@ describe EvilEvents::Core::Events::Serializers::JSON, :stub_event_system do
       it 'fails with appropriate deserialization error' do
         [double, 'kek', '{}test{}', 'las_-vegas metadata: {}'].each do |serialized_event|
           expect { described_class.deserialize(serialized_event) }.to(
-            raise_error(EvilEvents::DeserializationError)
+            raise_error(EvilEvents::JSONDeserializationError)
           )
         end
       end

--- a/spec/units/evil_events/core/events/serializers/json_spec.rb
+++ b/spec/units/evil_events/core/events/serializers/json_spec.rb
@@ -77,7 +77,7 @@ describe EvilEvents::Core::Events::Serializers::JSON, :stub_event_system do
 
       it 'fails with appropriate serialization exception' do
         expect { serialization }.to(
-          raise_error(EvilEvents::SerializationError)
+          raise_error(EvilEvents::JSONSerializationError)
         )
       end
     end

--- a/spec/units/evil_events/core/events/serializers/xml/event_serialization_state_spec.rb
+++ b/spec/units/evil_events/core/events/serializers/xml/event_serialization_state_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+describe EvilEvents::Core::Events::Serializers::XML::EventSerializationState, :stub_event_system do
+  specify 'mapped event attributes' do
+    event = build_event_class('test_event') do
+      payload :a
+      payload :b
+      payload :c
+
+      metadata :d
+      metadata :e
+      metadata :f
+    end.new(
+      payload:  { a: gen_int, b: gen_str,  c: gen_symb  },
+      metadata: { d: gen_str, e: gen_symb, f: gen_float }
+    )
+
+    state_map = described_class.new(event)
+
+    expect(state_map.instance_variables).to contain_exactly(:@id, :@type, :@metadata, :@payload)
+
+    expect(state_map.id).to       eq(event.id)
+    expect(state_map.type).to     eq(event.type)
+    expect(state_map.metadata).to match(event.metadata)
+    expect(state_map.payload).to  match(event.payload)
+  end
+end

--- a/spec/units/evil_events/core/events/serializers/xml_spec.rb
+++ b/spec/units/evil_events/core/events/serializers/xml_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+describe EvilEvents::Core::Events::Serializers::XML, :stub_event_system do
+  include_context 'event system'
+
+  describe '.serialize' do
+    context 'when received object is an event instance' do
+      it 'returns a string representation of an event with a corresponding xml format' do
+        # NOTE: this spec depends on Ox library
+
+        event = build_event_class('user_registered') do
+          payload :user_id, EvilEvents::Types::Strict::Int
+          payload :comment, EvilEvents::Types::Strict::String
+
+          metadata :author_id, EvilEvents::Types::Coercible::Int.default(-1)
+          metadata :timestamp
+        end.new(
+          id: gen_str,
+          payload: { user_id: gen_int, comment: gen_str },
+          metadata: { timestamp: gen_int }
+        )
+
+        serialization_state = described_class::EventSerializationState.new(event)
+
+        expect(Ox.dump(serialization_state)).to eq(described_class.serialize(event))
+      end
+
+      it 'each invokation provides a new xml string object (non-cachable)' do
+        test_event = build_event_class('test_event').new
+
+        first_serialization  = described_class.serialize(test_event)
+        second_serialization = described_class.serialize(test_event)
+
+        expect(first_serialization.object_id).not_to eq(second_serialization.object_id)
+      end
+    end
+
+    context 'when received object isnt an event instance' do
+      subject(:serialization) { described_class.serialize(double) }
+
+      it 'fails with corresponding serialization error' do
+        expect { serialization }.to(
+          raise_error(EvilEvents::XMLSerializationError)
+        )
+      end
+    end
+  end
+
+  describe '.deserialize' do
+    let!(:iphone_crashed_event_klass) do
+      build_event_class('iphone_crashed') do
+        payload :serial_no
+        payload :model
+
+        metadata :timestamp
+      end
+    end
+
+    let!(:iphone_crashed_event) do
+      iphone_crashed_event_klass.new(
+        payload: {
+          serial_no: gen_str,
+          model: gen_str
+        },
+        metadata: { timestamp: gen_int }
+      )
+    end
+
+    context 'when received object is a parsable xml string' do
+      context 'when passed xml representation has all required event fields' do
+        let(:xml) { described_class.serialize(iphone_crashed_event) }
+
+        it 'returns an instance of corresponding event' do
+          event = described_class.deserialize(xml)
+
+          expect(event).to          be_a(iphone_crashed_event_klass)
+          expect(event.id).to       eq(iphone_crashed_event.id)
+          expect(event.type).to     eq(iphone_crashed_event.type)
+          expect(event.payload).to  match(iphone_crashed_event.payload)
+          expect(event.metadata).to match(iphone_crashed_event.metadata)
+        end
+      end
+
+      context 'when passed xml representation represents non-registered event' do
+        let(:xml) do
+          described_class
+            .serialize(iphone_crashed_event)
+            .sub(iphone_crashed_event_klass.type, gen_str)
+        end
+
+        it 'fails with corresponding error' do
+          expect { described_class.deserialize(xml) }.to raise_error(
+            EvilEvents::NonManagedEventClassError
+          )
+        end
+      end
+
+      context 'when passed xml representation has incompatible event payload/matedata attrs' do
+        let(:xml) { described_class.serialize(iphone_crashed_event_klass.allocate) }
+
+        it 'fails with payload/metadata constructor error' do
+          expect { described_class.deserialize(xml) }.to raise_error(Dry::Struct::Error)
+        end
+      end
+    end
+
+    context 'when received object isnt a parsable xml string' do
+      let(:incored_xml_objects) { gen_all }
+
+      it 'fails with corresponding deserialization error' do
+        incored_xml_objects.each do |xml|
+          expect { described_class.deserialize(xml) }.to raise_error(
+            EvilEvents::XMLDeserializationError
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/units/evil_events/serializer_spec.rb
+++ b/spec/units/evil_events/serializer_spec.rb
@@ -31,4 +31,5 @@ describe EvilEvents::Serializer, :stub_event_system do
 
   it_behaves_like 'deserialization module', :json, :load_from_json, :deserialize_from_json
   it_behaves_like 'deserialization module', :hash, :load_from_hash, :deserialize_from_hash
+  it_behaves_like 'deserialization module', :xml,  :load_from_xml,  :deserialize_from_xml
 end


### PR DESCRIPTION
XML Serialization API (Ox library under the hood):
- `EvilEvents::Core::Events::AbstractEvent#serialize_to_xml`
- `EvilEvents::Core::Events::AbstractEvent#dump_to_xml`
- `EvilEvents::Serializer.load_from_xml`
- serialization module: `EvilEvents::Core::Events::Serializers::XML`

Added specific SerializationAPI errors (inherited from `EvilEvents::SerializationError`):
- `EvilEvents::JSONSerializationError`
- `EvilEvents::HashSerializationError`
- `EvilEvents::XMLSerializationError`
- `EvilEvents::JSONDeserializationError`
- `EvilEvents::HashDeserializationError`
- `EvilEvents::XMLDeserializationError`

Singature API:
- `AbstractEvent#similar_to?(another_event)` - checking that a passed event object has equal id/type/payload/metadata attributes of the current event
