### PR TITLE
Oj serialization engine (JSON format)

### DIFF
--- a/evil_events.gemspec
+++ b/evil_events.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'symbiont-ruby',    '~> 0.2.0'
   spec.add_dependency 'ox',               '~> 2.9.2'
   spec.add_dependency 'msgpack',          '~> 1.2.4'
+  spec.add_dependency 'oj',               '~> 3.6.0'
 
   spec.add_development_dependency 'coveralls',      '~> 0.8.21'
   spec.add_development_dependency 'simplecov',      '~> 0.14.1'

--- a/lib/evil_events.rb
+++ b/lib/evil_events.rb
@@ -13,6 +13,7 @@ require 'msgpack'
 require 'logger'
 require 'json'
 require 'ox'
+require 'oj'
 
 # @api public
 # @since 0.1.0

--- a/lib/evil_events/core/events.rb
+++ b/lib/evil_events/core/events.rb
@@ -14,6 +14,7 @@ module EvilEvents::Core
     require_relative 'events/serializers/json'
     require_relative 'events/serializers/json/engines'
     require_relative 'events/serializers/json/engines/native'
+    require_relative 'events/serializers/json/engines/oj'
     require_relative 'events/serializers/json/config'
     require_relative 'events/serializers/json/factory'
     require_relative 'events/serializers/json/packer'

--- a/lib/evil_events/core/events/serializers/json/engines/oj.rb
+++ b/lib/evil_events/core/events/serializers/json/engines/oj.rb
@@ -33,7 +33,7 @@ class EvilEvents::Core::Events::Serializers::JSON::Engines
         payload:  json[:payload],
         metadata: json[:metadata]
       )
-    rescue ::Oj::Error, NoMethodError, TypeError
+    rescue ::Oj::Error, NoMethodError, TypeError, ArgumentError
       raise EvilEvents::SerializationEngineError
     end
   end

--- a/lib/evil_events/core/events/serializers/json/engines/oj.rb
+++ b/lib/evil_events/core/events/serializers/json/engines/oj.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class EvilEvents::Core::Events::Serializers::JSON::Engines
+  # @api private
+  # @since 0.5.0
+  class Oj < EvilEvents::Core::Events::Serializers::Base::AbstractEngine
+    # @param serialization_state [Base::EventSerializationState]
+    # @return [String]
+    #
+    # @since 0.5.0
+    # @api private
+    def dump(serialization_state)
+      ::Oj.dump(
+        id:       serialization_state.id,
+        type:     serialization_state.type,
+        payload:  serialization_state.payload,
+        metadata: serialization_state.metadata
+      )
+    end
+
+    # @param json_string [String]
+    # @raise [EvilEvents::SerializationEngineError]
+    # @return [EventSerializationState]
+    #
+    # @since 0.5.0
+    # @api private
+    def load(json_string)
+      json = ::Oj.load(json_string, symbol_keys: true)
+
+      restore_serialization_state(
+        id:       json[:id],
+        type:     json[:type],
+        payload:  json[:payload],
+        metadata: json[:metadata]
+      )
+    rescue ::Oj::Error, NoMethodError, TypeError
+      raise EvilEvents::SerializationEngineError
+    end
+  end
+
+  # @since 0.5.0
+  register(:oj, Oj)
+end

--- a/spec/units/evil_events/core/events/serializers/json/engines/oj_spec.rb
+++ b/spec/units/evil_events/core/events/serializers/json/engines/oj_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe EvilEvents::Core::Events::Serializers::JSON::Engines::Native do
+describe EvilEvents::Core::Events::Serializers::JSON::Engines::Oj do
   let(:serialization_state) do
     build_serialization_state(
       id: gen_str,
@@ -17,7 +17,7 @@ describe EvilEvents::Core::Events::Serializers::JSON::Engines::Native do
 
   describe '#dump' do
     it 'returns json representation of event serialization state' do
-      native_json_dump = ::JSON.generate(
+      oj_dump = ::Oj.dump(
         id:       serialization_state.id,
         type:     serialization_state.type,
         payload:  serialization_state.payload,
@@ -27,7 +27,7 @@ describe EvilEvents::Core::Events::Serializers::JSON::Engines::Native do
       serialization = engine.dump(serialization_state)
 
       expect(serialization).to be_a(String)
-      expect(serialization).to match(native_json_dump)
+      expect(serialization).to match(oj_dump)
     end
 
     it 'each invocation returns new string object' do

--- a/spec/units/evil_events/core/events/serializers/json_spec.rb
+++ b/spec/units/evil_events/core/events/serializers/json_spec.rb
@@ -1,22 +1,36 @@
 # frozen_string_literal: true
 
 describe EvilEvents::Core::Events::Serializers::JSON, :stub_event_system do
-  it_behaves_like 'event serializer component' do
-    let(:serializer) { EvilEvents::Core::Events::Serializers::JSON::Factory.new.create! }
-    let(:serialization_error) { EvilEvents::JSONSerializationError }
-    let(:deserialization_error) { EvilEvents::JSONDeserializationError }
-    let(:serialization_type) { String }
-    let(:incorrect_deserialization_objects) { gen_all }
-    let(:invalid_serializations) do
-      data = serializer.serialize(event)
+  include_context 'event system'
 
-      [
-        data.sub('"type":', "\"#{gen_str}\":"),
-        data.sub('"payload":', "\"#{gen_str}\":"),
-        data.sub('"metadata":', "\"#{gen_str}\":")
-      ]
+  shared_examples 'serialization behaviour' do
+    it_behaves_like 'event serializer component' do
+      let(:serializer) { EvilEvents::Core::Events::Serializers::JSON::Factory.new.create! }
+      let(:serialization_error) { EvilEvents::JSONSerializationError }
+      let(:deserialization_error) { EvilEvents::JSONDeserializationError }
+      let(:serialization_type) { String }
+      let(:incorrect_deserialization_objects) { gen_all }
+      let(:invalid_serializations) do
+        data = serializer.serialize(event)
+
+        [
+          data.sub('type":', "\"#{gen_str}\":"),
+          data.sub('payload":', "\"#{gen_str}\":"),
+          data.sub('metadata":', "\"#{gen_str}\":")
+        ]
+      end
+
+      specify { expect(serializer).to be_a(described_class) }
     end
+  end
 
-    specify { expect(serializer).to be_a(described_class) }
+  context 'native engine' do
+    before { system_config.serializers.json.engine = :native }
+    it_behaves_like 'serialization behaviour'
+  end
+
+  context 'oj engine' do
+    before { system_config.serializers.json.engine = :oj }
+    it_behaves_like 'serialization behaviour'
   end
 end


### PR DESCRIPTION
- Requirements: `oj ~> 3.6.0`
- Setup: `EvilEvents::Config.configure { |c| c.serializers.json.engine = :oj }`