### PR TITLE
Good bye Ruby 2.2!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ script: bundle exec rspec
 matrix:
   fast_finish: true
   include:
-  - rvm: 2.2.10
-    gemfile: gemfiles/with_native_extensions.gemfile
-    env: TEST_NATIVE_EXTENSIONS=true
   - rvm: 2.3.7
     gemfile: gemfiles/with_native_extensions.gemfile
     env: TEST_NATIVE_EXTENSIONS=true
@@ -21,8 +18,6 @@ matrix:
   - rvm: ruby-head
     gemfile: gemfiles/with_native_extensions.gemfile
     env: TEST_NATIVE_EXTENSIONS=true
-  - rvm: 2.2.10
-    gemfile: gemfiles/without_native_extensions.gemfile
   - rvm: 2.3.7
     gemfile: gemfiles/without_native_extensions.gemfile
   - rvm: 2.4.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+## Changed
+- Dropped Ruby 2.2.x support;
+
 ## [0.5.0] - 2018-05-20
 ### Added
 - Added Oj serialization engine for JSON format;


### PR DESCRIPTION
**GG** https://www.ruby-lang.org/en/news/2018/06/20/support-of-ruby-2-2-has-ended/
